### PR TITLE
fix(ui): restore live stream updates in agent workspace modal

### DIFF
--- a/site/ui/components/chat-view.js
+++ b/site/ui/components/chat-view.js
@@ -217,7 +217,7 @@ function categorizeMessage(msg) {
 function isThinkingTraceMessage(msg) {
   if (!msg) return false;
   const category = categorizeMessage(msg);
-  if (category === "tool" || category === "result" || category === "error") {
+  if (category === "tool" || category === "result") {
     return true;
   }
   return (msg.type || "").toLowerCase() === "system";


### PR DESCRIPTION
## Summary
- ensure live session WS messages append for the currently loaded session stream, not only the globally selected session
- keep tool and result events grouped under Thinking, but render error/stream_error as normal error bubbles
- fixes agent workspace Stream tab appearing stalled with only reconnect traces while work is active

## Files
- site/ui/components/session-list.js
- site/ui/components/chat-view.js

## Validation
- npm test (75 files, 1717 tests passed)