### PR TITLE
ci: auto-attach bosun marker on all pull requests

### DIFF
--- a/.github/workflows/bosun-pr-attach.yml
+++ b/.github/workflows/bosun-pr-attach.yml
@@ -1,0 +1,82 @@
+name: "Bosun: Attach PR Marker"
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  attach:
+    name: Attach Bosun marker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure `bosun-attached` label exists
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const name = "bosun-attached";
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name });
+            } catch (err) {
+              if (err?.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color: "7c3aed",
+                  description: "Bosun PR attachment marker",
+                });
+              } else {
+                throw err;
+              }
+            }
+
+      - name: Apply label and idempotent marker comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const marker = "<!-- bosun-attached -->";
+            const body = `${marker}
+            🤖 Bosun attached.
+
+            This PR is tracked by Bosun attachment automation.
+            - Marker label: \\`bosun-attached\\`
+            - Trigger: \\`${context.eventName}\\` / \\`${context.payload.action}\\``;
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: ["bosun-attached"],
+            });
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            );
+            const existing = comments.find((c) =>
+              typeof c.body === "string" && c.body.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }


### PR DESCRIPTION
Add pull_request_target automation that ensures bosun-attached label + idempotent Bosun marker comment on every PR, including manual PRs.