### PR TITLE
fix(monitor): keep monitor alive on unexpected exceptions

### DIFF
--- a/tests/monitor-exception-resilience.test.mjs
+++ b/tests/monitor-exception-resilience.test.mjs
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+describe("monitor exception resilience guards", () => {
+  const monitorPath = resolve(process.cwd(), "monitor.mjs");
+  const source = readFileSync(monitorPath, "utf8");
+
+  it("does not terminate process inside handleMonitorFailure", () => {
+    const match = source.match(
+      /async function handleMonitorFailure\([\s\S]*?\n\}\n\nfunction reportGuardedFailure/,
+    );
+    expect(match, "handleMonitorFailure block should be present").toBeTruthy();
+    const body = match ? match[0] : "";
+    expect(body).not.toMatch(/process\.exit\(/);
+  });
+
+  it("uses guarded scheduler wrappers for monitor-level periodic tasks", () => {
+    expect(source).toContain('safeSetInterval("flush-error-queue"');
+    expect(source).toContain('safeSetInterval("maintenance-sweep"');
+    expect(source).toContain('safeSetInterval("merged-pr-check"');
+    expect(source).toContain('safeSetInterval("epic-merge-check"');
+    expect(source).toContain('safeSetInterval("fleet-sync"');
+  });
+
+  it("contains top-level startProcess exception containment", () => {
+    const startProcessMatch = source.match(
+      /async function startProcess\(\) \{[\s\S]*?\n\}\n\nfunction requestRestart/,
+    );
+    expect(startProcessMatch, "startProcess function should be present").toBeTruthy();
+    const block = startProcessMatch ? startProcessMatch[0] : "";
+    expect(block).toContain("try {");
+    expect(block).toContain('reportGuardedFailure("startProcess", err);');
+    expect(block).toContain('safeSetTimeout("startProcess-retry"');
+  });
+});


### PR DESCRIPTION
## Summary
- prevent exception hard-cap handling from terminating the monitor process
- add guarded scheduler helpers (unGuarded, safeSetInterval, safeSetTimeout) to contain sync/async timer failures
- wrap startProcess() in top-level exception containment with delayed retry
- migrate monitor/maintenance periodic timers and monitor-monitor supervisor timers to guarded scheduling
- add regression tests to lock in non-terminating failure handling

## Validation
- npm run syntax:check
- npx vitest run --config vitest.config.mjs tests/monitor-exception-resilience.test.mjs
- npm run build
- npm test