### PR TITLE
fix(monitor): prevent silent crash from stale PID lock and PID reuse

### DIFF
--- a/monitor.mjs
+++ b/monitor.mjs
@@ -12528,11 +12528,20 @@ if (!process.env.VITEST && !acquireMonitorLock(config.cacheDir)) {
   // shutting down and holding the lock briefly. Ask cli.mjs to retry instead
   // of treating this as a hard crash.
   if (isSelfRestart) {
-    console.warn(
-      "[monitor] self-restart lock handoff still busy — retrying startup",
+    // Write directly to stderr so the message reaches the terminal even when
+    // the console interceptor is redirecting to a log file.
+    process.stderr.write(
+      "[monitor] self-restart lock handoff still busy — retrying startup\n",
     );
     process.exit(SELF_RESTART_EXIT_CODE);
   }
+  // Write directly to stderr — console.error is intercepted to a log file at
+  // this point, so the user would see a silent exit-code-1 crash with zero
+  // explanation without this line.
+  process.stderr.write(
+    "[monitor] another bosun instance holds the lock — exiting (exit code 1).\n" +
+      "[monitor] If no other bosun is running, delete .cache/bosun.pid and retry.\n",
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
## Problem

The monitor crashes silently with exit code 1 and zero output, leaving the user with no idea why it will not start.

### Root causes

1. Stale PID lock file: When the monitor process dies, the .cache/bosun.pid file is left behind. On restart, acquireMonitorLock() finds a live process at the recycled PID and refuses to start.
2. PID reuse on Windows: Windows recycles PIDs aggressively. When classifyMonitorProcess() cannot read the command line of the reused PID, it returns unknown and the lock function blocks startup.
3. Silent exit: The singleton guard calls process.exit(1) without any visible output because console.error is redirected to a log file by the console interceptor.

## Fix

- monitor.mjs: Write directly to process.stderr in singleton guard so the user sees the reason for exit
- maintenance.mjs: Treat unknown PID classification as PID reuse (warn + replace lock) instead of hard-blocking
- Codex-agent changes: wrap timer callbacks in runGuarded/safeSetInterval/safeSetTimeout and replace hard process.exit(1) in handleMonitorFailure with degraded safe-mode

## Testing

All 1745 tests pass.