### PR TITLE
fix(workflows): stream planner events and honor explicit ephemeral UI port

### DIFF
--- a/ui-server.mjs
+++ b/ui-server.mjs
@@ -7138,12 +7138,17 @@ export async function startTelegramUiServer(options = {}) {
     process.env.BOSUN_UI_ALLOW_EPHEMERAL_PORT === "1" ||
     isTestRun;
   const persistedPort = readLastUiPort();
+  const shouldReusePersistedPort =
+    options.port == null &&
+    configuredPort === 0 &&
+    allowEphemeralPort &&
+    persistedPort > 0;
   const port =
-    configuredPort === 0 && allowEphemeralPort && persistedPort > 0
+    shouldReusePersistedPort
       ? persistedPort
       : configuredPort;
   const portSource =
-    configuredPort === 0 && allowEphemeralPort && persistedPort > 0
+    shouldReusePersistedPort
       ? "cache.ui-last-port"
       : options.port != null
       ? "options.port"


### PR DESCRIPTION
## Summary
- add live stream event logging and heartbeat progress logs to `agent.run_planner`
- extend stream event summarization to handle Codex/Copilot item/message shapes (thinking/tool/action visibility)
- propagate planner thread/session IDs for downstream workflow context
- honor explicit `port: 0` in `startTelegramUiServer()` instead of reusing cached UI port

## Validation
- `npm run build`
- `npm test -- tests/workflow-engine.test.mjs`
- `npm test -- tests/ui-server.test.mjs`
- `npm test` (full suite via pre-push hook)