### PR TITLE
fix: stabilize monitor shutdown and workspace recovery test

### DIFF
--- a/tests/workspace-manager.test.mjs
+++ b/tests/workspace-manager.test.mjs
@@ -240,5 +240,5 @@ describe("pullWorkspaceRepos", () => {
     const backupDir = wsEntries.find((entry) => entry.startsWith("bosun.non-git-backup-"));
     expect(backupDir).toBeTruthy();
     expect(existsSync(join(configDir, "workspaces", "alpha", backupDir, "stale.txt"))).toBe(true);
-  });
+  }, 60000);
 });


### PR DESCRIPTION
## Summary
- add safe no-op GitHub reconciler hooks to prevent monitor shutdown ReferenceError crashes
- extend workspace recovery integration test timeout to avoid false negatives in slower environments

## Validation
- npm run prepush:check
- npm run test:voice-provider-smoke
- npm run check:native-call-parity
- runtime smoke: npm start (verified startup and no reconciler crash)