### PR TITLE
fix: restore workflow task dispatch claim flow

### DIFF
--- a/tests/workflow-task-lifecycle.test.mjs
+++ b/tests/workflow-task-lifecycle.test.mjs
@@ -130,6 +130,47 @@ describe("trigger.task_available", () => {
     expect(result.tasks[0].id).toBe("t-server");
   });
 
+  it("binds primary task context for downstream lifecycle nodes", async () => {
+    const nt = getNodeType("trigger.task_available");
+    const listTasks = vi.fn().mockResolvedValue([
+      {
+        id: "abc-123",
+        title: "Implement dispatch fix",
+        description: "Ensure claims initialize",
+        status: "todo",
+        workspace: "C:/repo/bosun",
+        repository: "virtengine/bosun",
+        repositories: ["virtengine/bosun"],
+        baseBranch: "main",
+      },
+    ]);
+    const ctx = makeCtx({ activeSlotCount: 0 });
+    const node = makeNode("trigger.task_available", {
+      maxParallel: 1,
+      status: "todo",
+    });
+
+    const result = await nt.execute(node, ctx, {
+      services: {
+        kanban: {
+          listTasks,
+        },
+      },
+    });
+
+    expect(result.triggered).toBe(true);
+    expect(result.taskCount).toBe(1);
+    expect(result.selectedTaskId).toBe("abc-123");
+    expect(ctx.data.taskId).toBe("abc-123");
+    expect(ctx.data.taskTitle).toBe("Implement dispatch fix");
+    expect(ctx.data.taskDescription).toBe("Ensure claims initialize");
+    expect(ctx.data.repoRoot).toBe("C:/repo/bosun");
+    expect(ctx.data.workspace).toBe("C:/repo/bosun");
+    expect(ctx.data.repository).toBe("virtengine/bosun");
+    expect(ctx.data.baseBranch).toBe("main");
+    expect(ctx.data.branch.startsWith("task/abc123-")).toBe(true);
+  });
+
   it("returns blocked result when all tasks exceed repoAreaParallelLimit", async () => {
     const nt = getNodeType("trigger.task_available");
     const listTasks = vi.fn().mockResolvedValue([
@@ -438,6 +479,40 @@ describe("action.release_slot", () => {
     // Cleanup
     if (origVal === undefined) delete process.env.VE_RESTORE_TEST;
     else process.env.VE_RESTORE_TEST = origVal;
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  action.claim_task Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("action.claim_task", () => {
+  it("initializes task-claims lazily before claiming", async () => {
+    const nt = getNodeType("action.claim_task");
+    const claims = await import("../task/task-claims.mjs");
+    const initSpy = vi.spyOn(claims, "initTaskClaims").mockResolvedValue();
+    const claimSpy = vi.spyOn(claims, "claimTask").mockResolvedValue({
+      success: true,
+      token: "claim-token-1",
+    });
+
+    try {
+      const ctx = makeCtx({ repoRoot: "/tmp/repo-root" });
+      const node = makeNode("action.claim_task", {
+        taskId: "task-1",
+        taskTitle: "Fix dispatch",
+        renewIntervalMs: 0,
+      });
+      const result = await nt.execute(node, ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.claimToken).toBe("claim-token-1");
+      expect(initSpy).toHaveBeenCalled();
+      expect(claimSpy).toHaveBeenCalled();
+    } finally {
+      initSpy.mockRestore();
+      claimSpy.mockRestore();
+    }
   });
 });
 
@@ -1058,3 +1133,4 @@ describe("template-ve-orchestrator-lite", () => {
     expect(Array.isArray(t.variables.protectedBranches)).toBe(true);
   });
 });
+

--- a/workflow/workflow-nodes.mjs
+++ b/workflow/workflow-nodes.mjs
@@ -6893,6 +6893,7 @@ registerNodeType("transform.mcp_extract", {
 
 /** Module-scope lazy caches for task lifecycle imports. */
 let _taskClaimsMod = null;
+let _taskClaimsInitPromise = null;
 let _taskComplexityMod = null;
 let _kanbanAdapterMod = null;
 let _agentPoolMod = null;
@@ -6902,6 +6903,46 @@ let _diffStatsMod = null;
 async function ensureTaskClaimsMod() {
   if (!_taskClaimsMod) _taskClaimsMod = await import("../task/task-claims.mjs");
   return _taskClaimsMod;
+}
+function pickTaskString(...values) {
+  for (const value of values) {
+    const normalized = String(value || "").trim();
+    if (normalized) return normalized;
+  }
+  return "";
+}
+function deriveTaskBranch(task = {}) {
+  const explicit = pickTaskString(
+    task?.branch,
+    task?.branchName,
+    task?.meta?.branch,
+    task?.metadata?.branch,
+  );
+  if (explicit) return explicit;
+  const taskId = pickTaskString(task?.id, task?.task_id).replace(/[^a-zA-Z0-9]/g, "").slice(0, 12);
+  const titleSlug = pickTaskString(task?.title, "task")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  const suffix = titleSlug || "task";
+  if (taskId) return `task/${taskId}-${suffix}`;
+  return `task/${suffix}`;
+}
+async function ensureTaskClaimsInitialized(ctx, claims) {
+  if (typeof claims?.initTaskClaims !== "function") return;
+  if (!_taskClaimsInitPromise) {
+    const repoRoot = pickTaskString(
+      ctx?.data?.repoRoot,
+      ctx?.data?.workspace,
+      process.cwd(),
+    );
+    _taskClaimsInitPromise = claims.initTaskClaims({ repoRoot }).catch((err) => {
+      _taskClaimsInitPromise = null;
+      throw err;
+    });
+  }
+  await _taskClaimsInitPromise;
 }
 async function ensureTaskComplexityMod() {
   if (!_taskComplexityMod) _taskComplexityMod = await import("../task/task-complexity.mjs");
@@ -7256,12 +7297,54 @@ registerNodeType("trigger.task_available", {
       }
     }
 
+    const primaryTask = toDispatch[0] || null;
+    if (primaryTask) {
+      const taskId = pickTaskString(primaryTask.id, primaryTask.task_id);
+      const taskTitle = pickTaskString(primaryTask.title, primaryTask.task_title);
+      bindTaskContext(ctx, { taskId, taskTitle, task: primaryTask });
+      const taskDescription = pickTaskString(
+        primaryTask.description,
+        primaryTask.task_description,
+      );
+      if (taskDescription) ctx.data.taskDescription = taskDescription;
+      const taskWorkspace = pickTaskString(
+        primaryTask.workspace,
+        primaryTask.workspacePath,
+        primaryTask.meta?.workspace,
+        primaryTask.metadata?.workspace,
+      );
+      if (taskWorkspace) {
+        ctx.data.workspace = taskWorkspace;
+        if (!pickTaskString(ctx.data.repoRoot)) {
+          ctx.data.repoRoot = taskWorkspace;
+        }
+      }
+      const taskRepository = pickTaskString(
+        primaryTask.repository,
+        primaryTask.repo,
+        primaryTask.meta?.repository,
+        primaryTask.metadata?.repository,
+      );
+      if (taskRepository) ctx.data.repository = taskRepository;
+      const taskRepositories = Array.isArray(primaryTask.repositories)
+        ? primaryTask.repositories
+        : [];
+      if (taskRepositories.length > 0) {
+        ctx.data.repositories = taskRepositories;
+      }
+      const baseBranch = pickTaskString(primaryTask.baseBranch, primaryTask.base_branch);
+      if (baseBranch) ctx.data.baseBranch = baseBranch;
+      const branch = deriveTaskBranch(primaryTask);
+      if (branch) ctx.data.branch = branch;
+    }
+
     ctx.log(node.id, `Found ${toDispatch.length} task(s) ready (${remaining} slot(s) free)`);
     return {
       triggered: true,
       tasks: toDispatch,
       taskCount: toDispatch.length,
       availableSlots: remaining,
+      selectedTaskId: primaryTask ? pickTaskString(primaryTask.id, primaryTask.task_id) : "",
       auditEvents: startGuardAuditEvents,
     };
   },
@@ -7428,6 +7511,12 @@ registerNodeType("action.claim_task", {
     if (!taskId) throw new Error("action.claim_task: taskId is required");
 
     const claims = await ensureTaskClaimsMod();
+    try {
+      await ensureTaskClaimsInitialized(ctx, claims);
+    } catch (initErr) {
+      ctx.log(node.id, `Claim init failed: ${initErr.message}`);
+      return { success: false, error: initErr.message, taskId, alreadyClaimed: false };
+    }
 
     let claimResult;
     try {
@@ -7524,6 +7613,14 @@ registerNodeType("action.release_claim", {
     }
 
     const claims = await ensureTaskClaimsMod();
+    try {
+      await ensureTaskClaimsInitialized(ctx, claims);
+    } catch (initErr) {
+      ctx.log(node.id, `Claim release init warning: ${initErr.message}`);
+      ctx.data._claimToken = null;
+      ctx.data._claimInstanceId = null;
+      return { success: true, taskId, warning: initErr.message };
+    }
     try {
       await claims.releaseTaskClaim({ taskId, claimToken, instanceId });
       ctx.data._claimToken = null;


### PR DESCRIPTION
## Summary
- initialize task-claims lazily in workflow lifecycle claim/release nodes
- bind primary dispatch task context (task id/title/repo/branch/base) in 	rigger.task_available
- add lifecycle regression tests for context binding and lazy claim initialization

## Validation
- npm test -- tests/workflow-task-lifecycle.test.mjs tests/workflow-engine.test.mjs
- npm test
- npm run build