### PR TITLE
fix(workflow): prevent downstream execution when trigger evaluates false

### DIFF
--- a/tests/workflow-engine.test.mjs
+++ b/tests/workflow-engine.test.mjs
@@ -1461,6 +1461,40 @@ describe("WorkflowEngine trigger evaluation", () => {
     const hits = engine.evaluateScheduleTriggers();
     expect(hits.some((h) => h.workflowId === "task-poll-interval-wf")).toBe(false);
   });
+  it("does not traverse downstream nodes when a trigger returns triggered: false", async () => {
+    registerNodeType("test.should_not_run", {
+      describe: () => "Fails if executed",
+      schema: { type: "object", properties: {} },
+      async execute() {
+        throw new Error("downstream should not execute when trigger is false");
+      },
+    });
+
+    const wf = makeSimpleWorkflow(
+      [
+        {
+          id: "low-trigger",
+          type: "trigger.task_low",
+          label: "Task Low",
+          config: { threshold: 3 },
+        },
+        {
+          id: "should-not-run",
+          type: "test.should_not_run",
+          label: "Should Not Run",
+          config: {},
+        },
+      ],
+      [{ source: "low-trigger", target: "should-not-run" }],
+      { id: "task-low-skip-wf", name: "Task Low Skip Workflow" },
+    );
+    engine.save(wf);
+
+    const run = await engine.execute("task-low-skip-wf", { todoCount: 10 });
+    expect(run.errors).toHaveLength(0);
+    expect(run.getNodeStatus("low-trigger")).toBe(NodeStatus.COMPLETED);
+    expect(run.getNodeStatus("should-not-run")).toBe(NodeStatus.SKIPPED);
+  });
   it("evaluateScheduleTriggers skips disabled workflows", () => {
     const wf = {
       id: "sched-disabled",
@@ -2928,3 +2962,4 @@ describe("WorkflowEngine.getTaskTraceEvents", () => {
     expect(reread[0].taskId).toBe("TASK-TRACE-READBACK");
   });
 });
+

--- a/workflow/workflow-engine.mjs
+++ b/workflow/workflow-engine.mjs
@@ -1791,6 +1791,7 @@ export class WorkflowEngine extends EventEmitter {
         const node = nodeMap.get(nodeId);
         const edges = adjacency.get(nodeId) || [];
         const sourceOutput = ctx.getNodeOutput(nodeId);
+        const triggerBlocked = node?.type?.startsWith("trigger.") && sourceOutput?.triggered === false;
         const selectedPortRaw =
           sourceOutput?.matchedPort ??
           sourceOutput?.port ??
@@ -1799,6 +1800,19 @@ export class WorkflowEngine extends EventEmitter {
           typeof selectedPortRaw === "string" && selectedPortRaw.trim()
             ? selectedPortRaw.trim()
             : null;
+
+        if (triggerBlocked) {
+          for (const edge of edges) {
+            if (edge.backEdge) continue;
+            const newDegree = (inDegree.get(edge.target) || 1) - 1;
+            inDegree.set(edge.target, newDegree);
+            if (newDegree <= 0 && !executed.has(edge.target)) {
+              ctx.setNodeStatus(edge.target, NodeStatus.SKIPPED);
+              executed.add(edge.target);
+            }
+          }
+          continue;
+        }
 
         // Handle loop.for_each: iterate downstream subgraph per item
         if (node?.type === "loop.for_each" && ctx.getNodeStatus(nodeId) === NodeStatus.COMPLETED) {
@@ -2638,5 +2652,6 @@ export function listWorkflows(opts) { return getWorkflowEngine(opts).list(); }
 export function getWorkflow(id, opts) { return getWorkflowEngine(opts).get(id); }
 export async function executeWorkflow(id, data, opts) { return getWorkflowEngine(opts).execute(id, data, opts); }
 export async function retryWorkflowRun(runId, retryOpts, engineOpts) { return getWorkflowEngine(engineOpts).retryRun(runId, retryOpts); }
+
 
 


### PR DESCRIPTION
## Summary
- stop DAG traversal from trigger nodes when they return 	riggered: false
- mark newly-unblocked immediate downstream nodes as skipped instead of executing them
- add regression coverage to ensure a false trigger does not run downstream actions

## Validation
- 
pm test -- tests/workflow-engine.test.mjs
- 
pm test
- 
pm run build
- 
pm run prepush:check (rerun; full-suite flake observed on prior attempts)
- git pre-push targeted suite (14 files / 883 tests) passed during push