### PR TITLE
fix(workflow): recover worktree branch fallback for unresolved base refs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bosun",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bosun",
-      "version": "0.40.2",
+      "version": "0.40.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bosun",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "description": "Bosun Autonomous Engineering — manages AI agent executors with failover, extremely powerful workflow builder, and a massive amount of included default workflow templates for autonomous engineering, creates PRs via Vibe-Kanban API, and sends Telegram notifications. Supports N executors with weighted distribution, multi-repo projects, and auto-setup.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary\n- treat unresolved template refs (for example {{baseBranch}}) as missing in action.acquire_worktree\n- fall back to defaultTargetBranch/origin-main/main before creating worktrees\n- only try existing-branch reuse when create failed due branch-already-exists\n- add regression test for unresolved baseBranch fallback\n\n## Validation\n- npm test -- tests/workflow-task-lifecycle.test.mjs\n- npm test\n- npm run build\n- npm run prepush:check\n