### PR TITLE
fix(workflow): recover worktree branch fallback for unresolved base refs

### DIFF
--- a/tests/workflow-task-lifecycle.test.mjs
+++ b/tests/workflow-task-lifecycle.test.mjs
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
@@ -555,6 +555,54 @@ describe("action.resolve_executor", () => {
     });
     const result = await nt.execute(node, ctx);
     expect(ctx.data.resolvedSdk).toBeDefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  action.acquire_worktree Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("action.acquire_worktree", () => {
+  let repoDir;
+
+  const gitExec = (command, options = {}) =>
+    execSync(command, {
+      env: sanitizedGitEnv(),
+      ...options,
+    });
+
+  beforeEach(() => {
+    repoDir = mkdtempSync(join(tmpdir(), "wf-acquire-worktree-"));
+    gitExec("git init", { cwd: repoDir, stdio: "ignore" });
+    gitExec("git config --local user.email test@test.com", { cwd: repoDir, stdio: "ignore" });
+    gitExec("git config --local user.name Test", { cwd: repoDir, stdio: "ignore" });
+    writeFileSync(join(repoDir, "README.md"), "init\n");
+    gitExec("git add README.md && git commit -m init", { cwd: repoDir, stdio: "ignore" });
+    gitExec("git branch -M main", { cwd: repoDir, stdio: "ignore" });
+  });
+
+  afterEach(() => {
+    try { rmSync(repoDir, { recursive: true, force: true }); } catch { /* ok */ }
+  });
+
+  it("falls back to defaultTargetBranch when baseBranch template is unresolved", async () => {
+    const nt = getNodeType("action.acquire_worktree");
+    const ctx = makeCtx({});
+    const node = makeNode("action.acquire_worktree", {
+      repoRoot: repoDir,
+      taskId: "abc123",
+      branch: "task/abc123-fallback-branch",
+      baseBranch: "{{baseBranch}}",
+      defaultTargetBranch: "main",
+      fetchTimeout: 5000,
+      worktreeTimeout: 10000,
+    });
+
+    const result = await nt.execute(node, ctx);
+    expect(result.success).toBe(true);
+    expect(result.baseBranch).toBe("main");
+    expect(result.created).toBe(true);
+    expect(existsSync(result.worktreePath)).toBe(true);
   });
 });
 

--- a/workflow/workflow-nodes.mjs
+++ b/workflow/workflow-nodes.mjs
@@ -7004,6 +7004,40 @@ function cfgOrCtx(node, ctx, key, defaultVal = "") {
   return defaultVal;
 }
 
+function isUnresolvedTemplateToken(value) {
+  return /{{[^{}]+}}/.test(String(value || ""));
+}
+
+function normalizeGitRefValue(value) {
+  const text = String(value ?? "").trim();
+  if (!text || isUnresolvedTemplateToken(text)) return "";
+  const lowered = text.toLowerCase();
+  if (lowered === "null" || lowered === "undefined") return "";
+  return text;
+}
+
+function pickGitRef(...candidates) {
+  for (const candidate of candidates) {
+    const normalized = normalizeGitRefValue(candidate);
+    if (normalized) return normalized;
+  }
+  return "";
+}
+
+function formatExecSyncError(err) {
+  if (!err) return "unknown error";
+  const detail = [err?.stderr, err?.stdout, err?.message]
+    .map((entry) => String(entry || "").trim())
+    .filter(Boolean)
+    .join(" | ");
+  return trimLogText(detail || String(err?.message || err), 420);
+}
+
+function isExistingBranchWorktreeError(err) {
+  const detail = formatExecSyncError(err).toLowerCase();
+  return detail.includes("already exists") || detail.includes("is already checked out");
+}
+
 /**
  * Anti-thrash state — module-scope to survive across workflow runs.
  * Mirrors TaskExecutor._noCommitCounts / _skipUntil / _completedWithPR.
@@ -7742,7 +7776,9 @@ registerNodeType("action.acquire_worktree", {
     const taskId = cfgOrCtx(node, ctx, "taskId");
     const branch = cfgOrCtx(node, ctx, "branch");
     const repoRoot = cfgOrCtx(node, ctx, "repoRoot") || process.cwd();
-    const baseBranch = cfgOrCtx(node, ctx, "baseBranch", "origin/main");
+    const baseBranchRaw = cfgOrCtx(node, ctx, "baseBranch", "origin/main");
+    const defaultTargetBranch = cfgOrCtx(node, ctx, "defaultTargetBranch", "origin/main");
+    const baseBranch = pickGitRef(baseBranchRaw, defaultTargetBranch, "origin/main", "main");
     const fetchTimeout = node.config?.fetchTimeout ?? 30000;
     const worktreeTimeout = node.config?.worktreeTimeout ?? 60000;
 
@@ -7799,15 +7835,21 @@ registerNodeType("action.acquire_worktree", {
           `git worktree add "${worktreePath}" -b "${branch}" "${baseBranch}" 2>&1`,
           { cwd: repoRoot, encoding: "utf8", timeout: worktreeTimeout },
         );
-      } catch {
-        // Branch may already exist — try checkout
+      } catch (createErr) {
+        if (!isExistingBranchWorktreeError(createErr)) {
+          throw new Error(`Worktree creation failed: ${formatExecSyncError(createErr)}`);
+        }
+        // Branch already exists — attach worktree to existing branch.
         try {
           execSync(
             `git worktree add "${worktreePath}" "${branch}" 2>&1`,
             { cwd: repoRoot, encoding: "utf8", timeout: worktreeTimeout },
           );
-        } catch (err2) {
-          throw new Error(`Worktree creation failed: ${err2.message}`);
+        } catch (reuseErr) {
+          throw new Error(
+            `Worktree creation failed: ${formatExecSyncError(createErr)}; ` +
+            `reuse failed: ${formatExecSyncError(reuseErr)}`,
+          );
         }
       }
 


### PR DESCRIPTION
## Summary\n- treat unresolved template refs (for example {{baseBranch}}) as missing in action.acquire_worktree\n- fall back to defaultTargetBranch/origin-main/main before creating worktrees\n- only try existing-branch reuse when create failed due branch-already-exists\n- add regression test for unresolved baseBranch fallback\n\n## Validation\n- npm test -- tests/workflow-task-lifecycle.test.mjs\n- npm test\n- npm run build\n- npm run prepush:check\n