### PR TITLE
fix: unblock autonomous reviews when PR diff context is missing

### DIFF
--- a/.bosun-monitor/sessions.md
+++ b/.bosun-monitor/sessions.md
@@ -202,3 +202,18 @@ ode cli.mjs --daemon-status (with explicit local config) reports running.
   - One active long-running Task Lifecycle run remains expected; no frozen active-run pair after remediation.
 - Residual risk:
   - Task stats CLI (80 tasks) and planner trigger store can still diverge depending on which runtime store is queried; monitor in next run and consider code-level store-path unification if divergence recurs.
+
+### Session 2026-03-09T01:50:16+11:00
+- Incident: workflow/task progression stalled while daemon appeared alive; unresolved task-id template warnings were recurring.
+- Diagnosis:
+  - monitor log showed repeated `setTaskStatus: task {{task.taskId}} not found` and internal status-update failures.
+  - schedule polling needed to keep running through task lifecycle/review handoff without poisoning by unresolved IDs.
+- Fix shipped:
+  - `infra/monitor.mjs`: added `hasUnresolvedTemplateToken` and guard in `resolveTaskIdForBackend` to skip unresolved `{{...}}` IDs.
+  - tests updated: `tests/monitor-workflow-startup-guards.test.mjs`, `tests/cli-daemon-pid-files.test.mjs`.
+- Verification:
+  - full gates passed: `npm test`, `npm run build`, `npm run prepush:check`.
+  - PR #174 merged to main (`333666c0d5e1471ebbdc12d4c577dff462182d72`).
+  - post-merge source daemon restart validated with minute cadence schedule polls and fresh `todo -> inprogress` transitions.
+- Operational note:
+  - Keep using workspace-local log/state paths under `bosun/.bosun/...` for source daemon checks; old AppData logs can be stale for this mode.

--- a/agent/review-agent.mjs
+++ b/agent/review-agent.mjs
@@ -122,24 +122,36 @@ function extractRepoSlug(prUrl) {
 
 /**
  * Get the PR diff using `gh pr diff` or `git diff`.
- * @param {{ prUrl?: string, branchName?: string }} opts
+ * @param {{ prUrl?: string, prNumber?: number|string, repoSlug?: string, branchName?: string, cwd?: string|null }} opts
  * @returns {{ diff: string, truncated: boolean }}
  */
-function getPrDiff({ prUrl, branchName }) {
+function getPrDiff({ prUrl, prNumber, repoSlug, branchName, cwd }) {
   let diff = "";
+  const commandOptions = {
+    encoding: "utf8",
+    timeout: 30_000,
+    stdio: ["pipe", "pipe", "pipe"],
+    ...(cwd ? { cwd } : {}),
+  };
 
   // Strategy 1: gh pr diff
-  const prNumber = extractPrNumber(prUrl);
-  const repoSlug = extractRepoSlug(prUrl);
-  if (prNumber && repoSlug) {
+  const resolvedPrNumber = Number.isFinite(Number(prNumber))
+    ? Number(prNumber)
+    : extractPrNumber(prUrl);
+  const resolvedRepoSlug = String(repoSlug || "").trim() || extractRepoSlug(prUrl);
+  if (resolvedPrNumber) {
     try {
-      const result = spawnSync(
-        "gh",
-        ["pr", "diff", String(prNumber), "--repo", repoSlug],
-        { encoding: "utf8", timeout: 30_000, stdio: ["pipe", "pipe", "pipe"] },
-      );
-      if (result.status === 0 && result.stdout?.trim()) {
-        diff = result.stdout;
+      const attempts = [];
+      if (resolvedRepoSlug) {
+        attempts.push(["pr", "diff", String(resolvedPrNumber), "--repo", resolvedRepoSlug]);
+      }
+      attempts.push(["pr", "diff", String(resolvedPrNumber)]);
+      for (const args of attempts) {
+        const result = spawnSync("gh", args, commandOptions);
+        if (result.status === 0 && result.stdout?.trim()) {
+          diff = result.stdout;
+          break;
+        }
       }
     } catch {
       /* fall through to git diff */
@@ -149,13 +161,16 @@ function getPrDiff({ prUrl, branchName }) {
   // Strategy 2: git diff main...<branch>
   if (!diff && branchName) {
     try {
-      const result = spawnSync("git", ["diff", `main...${branchName}`], {
-        encoding: "utf8",
-        timeout: 30_000,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-      if (result.status === 0 && result.stdout?.trim()) {
-        diff = result.stdout;
+      const attempts = [
+        ["diff", `origin/main...${branchName}`],
+        ["diff", `main...${branchName}`],
+      ];
+      for (const args of attempts) {
+        const result = spawnSync("git", args, commandOptions);
+        if (result.status === 0 && result.stdout?.trim()) {
+          diff = result.stdout;
+          break;
+        }
       }
     } catch {
       /* ignore */
@@ -343,6 +358,17 @@ export class ReviewAgent {
       console.warn(`${TAG} queueReview called without task id — skipping`);
       return;
     }
+    const hasReviewReference = Boolean(
+      String(task.prUrl || "").trim() ||
+        String(task.prNumber || "").trim() ||
+        String(task.branchName || "").trim(),
+    );
+    if (!hasReviewReference) {
+      console.warn(
+        `${TAG} queueReview skipped for ${task.id}: no prUrl, prNumber, or branchName`,
+      );
+      return;
+    }
 
     if (this.#seen.has(task.id)) {
       console.log(`${TAG} task ${task.id} already queued/in-flight — skipping`);
@@ -463,7 +489,10 @@ export class ReviewAgent {
     // 1. Get PR diff
     const { diff, truncated } = getPrDiff({
       prUrl: task.prUrl,
+      prNumber: task.prNumber,
+      repoSlug: task.repoSlug,
       branchName: task.branchName,
+      cwd: task.worktreePath || null,
     });
 
     if (!diff) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bosun",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bosun",
-      "version": "0.40.4",
+      "version": "0.40.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bosun",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "description": "Bosun Autonomous Engineering — manages AI agent executors with failover, extremely powerful workflow builder, and a massive amount of included default workflow templates for autonomous engineering, creates PRs via Vibe-Kanban API, and sends Telegram notifications. Supports N executors with weighted distribution, multi-repo projects, and auto-setup.",
   "type": "module",
   "license": "Apache-2.0",
@@ -129,6 +129,7 @@
     "bench:swebench:import": "node bench/swebench/bosun-swebench.mjs import",
     "bench:swebench:export": "node bench/swebench/bosun-swebench.mjs export",
     "bench:swebench:eval": "node bench/swebench/bosun-swebench.mjs eval",
+    "bench:library:resolver": "node bench/library/library-resolver-bench.mjs",
     "mutate": "npx stryker run",
     "mutate:incremental": "npx stryker run --incremental",
     "mutate:report": "node scripts/mutation-report.mjs",

--- a/tests/review-agent.test.mjs
+++ b/tests/review-agent.test.mjs
@@ -1,4 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
+
 import { createReviewAgent, ReviewAgent } from "../agent/review-agent.mjs";
 
 /* eslint-disable no-unused-vars */
@@ -35,6 +42,23 @@ describe("review-agent", () => {
       await new Promise((r) => setTimeout(r, 20));
     }
   }
+
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockImplementation((cmd, args) => {
+      if (cmd === "gh" && args?.[0] === "pr" && args?.[1] === "diff") {
+        return { status: 0, stdout: "diff --git a/file.mjs b/file.mjs\n+change\n" };
+      }
+      if (cmd === "git" && args?.[0] === "diff") {
+        return { status: 0, stdout: "diff --git a/fallback.mjs b/fallback.mjs\n+fallback\n" };
+      }
+      return { status: 1, stdout: "", stderr: "not mocked" };
+    });
+  });
+
+  afterEach(() => {
+    spawnSyncMock.mockReset();
+  });
 
   describe("ReviewAgent constructor", () => {
     it("creates instance with defaults", () => {
@@ -185,4 +209,47 @@ describe("review-agent", () => {
       await agent.stop();
     });
   });
+
+
+  describe("diff retrieval", () => {
+    it("uses prNumber-only context to fetch diff", async () => {
+      const onReviewComplete = vi.fn();
+      const agent = createReviewAgent({ onReviewComplete });
+      agent.start();
+
+      await agent.queueReview({
+        id: "task-pr-number",
+        title: "PR only",
+        prNumber: 123,
+        description: "",
+      });
+
+      await waitFor(() => onReviewComplete.mock.calls.length > 0);
+      expect(spawnSyncMock).toHaveBeenCalledWith(
+        "gh",
+        ["pr", "diff", "123"],
+        expect.objectContaining({ encoding: "utf8" }),
+      );
+      expect(onReviewComplete.mock.calls[0][1].approved).toBe(true);
+      await agent.stop();
+    });
+
+    it("skips queueing when review context is missing", async () => {
+      const onReviewComplete = vi.fn();
+      const agent = createReviewAgent({ onReviewComplete });
+      agent.start();
+
+      await agent.queueReview({
+        id: "task-no-context",
+        title: "No context",
+        description: "",
+      });
+
+      await new Promise((r) => setTimeout(r, 100));
+      expect(onReviewComplete).not.toHaveBeenCalled();
+      expect(agent.getStatus().queuedReviews).toBe(0);
+      await agent.stop();
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary\n- accept review tasks that provide only prNumber and resolve diffs via gh/git with safer fallbacks\n- skip queueing review tasks that have no prUrl/prNumber/branchName to prevent repeated false 'No diff' rejects\n- add regression tests for prNumber-only diff retrieval and missing-context skip behavior\n\n## Validation\n- npm test -- tests/review-agent.test.mjs\n- npm test\n- npm run build\n- npm run prepush:check