### PR TITLE
fix(monitor): honor BOSUN_PROMPT_PLANNER for planner fallback

### DIFF
--- a/infra/monitor.mjs
+++ b/infra/monitor.mjs
@@ -688,6 +688,24 @@ function resolvePlannerPromptFallback() {
     };
   }
 
+  const envPlannerPath = String(process.env.BOSUN_PROMPT_PLANNER || "").trim();
+  if (envPlannerPath) {
+    try {
+      if (existsSync(envPlannerPath)) {
+        const promptFromEnvPath = normalizePromptBody(readFileSync(envPlannerPath, "utf8"));
+        if (promptFromEnvPath) {
+          return {
+            prompt: promptFromEnvPath,
+            source: "env",
+            details: `BOSUN_PROMPT_PLANNER=${envPlannerPath}`,
+          };
+        }
+      }
+    } catch {
+      // best effort
+    }
+  }
+
   const workspaceRoot = String(repoRoot || process.cwd()).trim() || process.cwd();
   try {
     syncAutoDiscoveredLibraryEntries(workspaceRoot);

--- a/tests/monitor-workflow-startup-guards.test.mjs
+++ b/tests/monitor-workflow-startup-guards.test.mjs
@@ -65,6 +65,11 @@ describe("monitor workflow startup guards", () => {
       "CLI command mode in source checkout",
     );
   });
+  it("uses BOSUN_PROMPT_PLANNER path before workspace-root planner fallback", () => {
+    expect(monitorSource).toContain("process.env.BOSUN_PROMPT_PLANNER");
+    expect(monitorSource).toContain("BOSUN_PROMPT_PLANNER=");
+  });
+
   it("guards backend task-id resolution against unresolved template tokens", () => {
     expect(monitorSource).toContain("function hasUnresolvedTemplateToken(value)");
     expect(monitorSource).toContain("if (!rawId || hasUnresolvedTemplateToken(rawId)) return null;");


### PR DESCRIPTION
## Summary
- honor BOSUN_PROMPT_PLANNER in monitor planner-prompt fallback before workspace-root lookup
- keep existing config/library/file fallback chain unchanged
- add startup-guard regression assertion covering env planner-path fallback

## Validation
- npm test -- tests/monitor-workflow-startup-guards.test.mjs
- npm test
- npm run build
- npm run prepush:check