### PR TITLE
feat(agents): export session diagnostics bundle

### DIFF
--- a/.github/hooks/bosun.hooks.json
+++ b/.github/hooks/bosun.hooks.json
@@ -5,7 +5,7 @@
       "type": "command",
       "command": [
         "node",
-        "agent/agent-hook-bridge.mjs",
+        "C:\\Users\\jON\\Documents\\source\\repos\\virtengine-gh\\bosun\\agent\\agent-hook-bridge.mjs",
         "--agent",
         "copilot",
         "--event",
@@ -19,7 +19,7 @@
       "type": "command",
       "command": [
         "node",
-        "agent/agent-hook-bridge.mjs",
+        "C:\\Users\\jON\\Documents\\source\\repos\\virtengine-gh\\bosun\\agent\\agent-hook-bridge.mjs",
         "--agent",
         "copilot",
         "--event",
@@ -34,7 +34,7 @@
         "type": "command",
         "command": [
           "node",
-          "agent/agent-hook-bridge.mjs",
+          "C:\\Users\\jON\\Documents\\source\\repos\\virtengine-gh\\bosun\\agent\\agent-hook-bridge.mjs",
           "--agent",
           "copilot",
           "--event",
@@ -50,7 +50,7 @@
         "type": "command",
         "command": [
           "node",
-          "agent/agent-hook-bridge.mjs",
+          "C:\\Users\\jON\\Documents\\source\\repos\\virtengine-gh\\bosun\\agent\\agent-hook-bridge.mjs",
           "--agent",
           "copilot",
           "--event",

--- a/.github/hooks/bosun.hooks.json
+++ b/.github/hooks/bosun.hooks.json
@@ -5,7 +5,7 @@
       "type": "command",
       "command": [
         "node",
-        "C:\\Users\\jON\\Documents\\source\\repos\\virtengine-gh\\bosun\\agent\\agent-hook-bridge.mjs",
+        "agent/agent-hook-bridge.mjs",
         "--agent",
         "copilot",
         "--event",
@@ -19,7 +19,7 @@
       "type": "command",
       "command": [
         "node",
-        "C:\\Users\\jON\\Documents\\source\\repos\\virtengine-gh\\bosun\\agent\\agent-hook-bridge.mjs",
+        "agent/agent-hook-bridge.mjs",
         "--agent",
         "copilot",
         "--event",
@@ -34,7 +34,7 @@
         "type": "command",
         "command": [
           "node",
-          "C:\\Users\\jON\\Documents\\source\\repos\\virtengine-gh\\bosun\\agent\\agent-hook-bridge.mjs",
+          "agent/agent-hook-bridge.mjs",
           "--agent",
           "copilot",
           "--event",
@@ -50,7 +50,7 @@
         "type": "command",
         "command": [
           "node",
-          "C:\\Users\\jON\\Documents\\source\\repos\\virtengine-gh\\bosun\\agent\\agent-hook-bridge.mjs",
+          "agent/agent-hook-bridge.mjs",
           "--agent",
           "copilot",
           "--event",

--- a/lib/session-insights.mjs
+++ b/lib/session-insights.mjs
@@ -225,12 +225,123 @@ function parseContextBreakdown(text) {
 function normalizeUsage(value) {
   if (!value || typeof value !== "object") return null;
   const input =
-    Number(value.input_tokens ?? value.prompt_tokens ?? value.input ?? value.prompt ?? 0) || 0;
+    Number(
+      value.inputTokens
+      ?? value.input_tokens
+      ?? value.promptTokens
+      ?? value.prompt_tokens
+      ?? value.input
+      ?? value.prompt
+      ?? 0,
+    ) || 0;
   const output =
-    Number(value.output_tokens ?? value.completion_tokens ?? value.output ?? value.completion ?? 0) || 0;
-  const total = Number(value.total_tokens ?? value.total ?? input + output) || 0;
+    Number(
+      value.outputTokens
+      ?? value.output_tokens
+      ?? value.completionTokens
+      ?? value.completion_tokens
+      ?? value.output
+      ?? value.completion
+      ?? 0,
+    ) || 0;
+  const total = Number(value.totalTokens ?? value.total_tokens ?? value.total ?? input + output) || 0;
   if (input <= 0 && output <= 0 && total <= 0) return null;
   return { input, output, total };
+}
+
+function normalizeTokenUsageShape(value) {
+  const usage = normalizeUsage(value);
+  if (!usage) return null;
+  return {
+    inputTokens: usage.input,
+    outputTokens: usage.output,
+    totalTokens: usage.total,
+  };
+}
+
+function pickString(...values) {
+  for (const value of values) {
+    const normalized = String(value || "").trim();
+    if (normalized) return normalized;
+  }
+  return null;
+}
+
+function toIsoString(value) {
+  const text = String(value || "").trim();
+  if (!text) return null;
+  const parsed = Date.parse(text);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : text;
+}
+
+function toPositiveNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) && num >= 0 ? num : null;
+}
+
+function normalizeDiagnosticsTurn(turn = {}, index = 0) {
+  const usage =
+    normalizeTokenUsageShape(turn?.tokenUsage)
+    || normalizeTokenUsageShape(turn?.usage)
+    || normalizeTokenUsageShape(turn?.meta?.usage)
+    || null;
+  return {
+    id: pickString(turn?.id, turn?.turnId, `turn-${index + 1}`),
+    index: Number.isFinite(Number(turn?.index)) ? Math.max(0, Math.trunc(Number(turn.index))) : index,
+    status: pickString(turn?.status, turn?.state) || "unknown",
+    startedAt: toIsoString(turn?.startedAt || turn?.timestamp),
+    endedAt: toIsoString(turn?.endedAt),
+    durationMs: toPositiveNumber(turn?.durationMs),
+    summary: pickString(turn?.summary, turn?.title, turn?.preview, turn?.content),
+    inputTokens: usage?.inputTokens || 0,
+    outputTokens: usage?.outputTokens || 0,
+    totalTokens: usage?.totalTokens || 0,
+  };
+}
+
+function normalizeDiagnosticsMessage(message = {}, index = 0) {
+  const usage =
+    normalizeTokenUsageShape(message?.meta?.usage)
+    || normalizeTokenUsageShape(message?.usage)
+    || normalizeTokenUsageShape(message?.meta?.tokenUsage)
+    || null;
+  return {
+    id: pickString(message?.id, message?.messageId, `message-${index + 1}`),
+    role: pickString(message?.role, message?.type) || "unknown",
+    type: pickString(message?.type, message?.role) || "message",
+    timestamp: toIsoString(message?.timestamp || message?.createdAt),
+    content: toText(message?.content).slice(0, 4000),
+    inputTokens: usage?.inputTokens || 0,
+    outputTokens: usage?.outputTokens || 0,
+    totalTokens: usage?.totalTokens || 0,
+  };
+}
+
+function normalizeDiagnosticsWorkflowRun(run = {}) {
+  const issueAdvisor =
+    run?.issueAdvisor && typeof run.issueAdvisor === "object"
+      ? {
+          recommendedAction: pickString(run.issueAdvisor.recommendedAction, run.issueAdvisor.action),
+          summary: pickString(run.issueAdvisor.summary),
+        }
+      : null;
+  return {
+    runId: pickString(run?.runId, run?.id),
+    workflowId: pickString(run?.workflowId),
+    workflowName: pickString(run?.workflowName, run?.name),
+    status: pickString(run?.status) || "unknown",
+    sessionId: pickString(run?.sessionId),
+    primarySessionId: pickString(run?.primarySessionId, run?.sessionId),
+    startedAt: toIsoString(run?.startedAt),
+    endedAt: toIsoString(run?.endedAt),
+    durationMs: toPositiveNumber(run?.durationMs ?? run?.duration),
+    issueAdvisor,
+    plannerSummary: pickString(
+      run?.proofSummary?.plannerSummary,
+      run?.proofBundle?.summary?.plannerSummary,
+      run?.plannerTimeline?.at?.(-1)?.summary,
+    ),
+  };
 }
 
 export function formatCompactCount(value) {
@@ -419,5 +530,108 @@ export function buildSessionInsights(fullSession = null) {
     tokenUsage: persisted.tokenUsage || derived.tokenUsage,
     activityDiff: persisted.activityDiff || derived.activityDiff,
     generatedAt: persisted.generatedAt || derived.generatedAt,
+  };
+}
+
+export function buildSessionDiagnosticsBundle(fullSession = null, options = {}) {
+  const session = fullSession && typeof fullSession === "object" ? fullSession : {};
+  const exportedAt = toIsoString(options?.exportedAt) || new Date().toISOString();
+  const insights = buildSessionInsights(session);
+  const tokenUsage =
+    normalizeTokenUsageShape(session?.tokenUsage)
+    || normalizeTokenUsageShape(insights?.tokenUsage)
+    || null;
+  const contextWindow =
+    insights?.contextWindow && typeof insights.contextWindow === "object"
+      ? {
+          usedTokens: toPositiveNumber(insights.contextWindow.usedTokens),
+          totalTokens: toPositiveNumber(insights.contextWindow.totalTokens),
+          percent: Number.isFinite(Number(insights.contextWindow.percent))
+            ? Number(insights.contextWindow.percent)
+            : null,
+        }
+      : null;
+  const turns = (Array.isArray(session?.turns) ? session.turns : [])
+    .slice(-Math.max(1, Number(options?.recentTurnLimit) || 6))
+    .map((turn, index) => normalizeDiagnosticsTurn(turn, index));
+  const recentMessages = (Array.isArray(session?.messages) ? session.messages : [])
+    .filter((message) => {
+      const type = String(message?.type || "").toLowerCase();
+      return type !== "tool_result" && type !== "tool_output" && type !== "system";
+    })
+    .slice(-Math.max(1, Number(options?.recentMessageLimit) || 12))
+    .map((message, index) => normalizeDiagnosticsMessage(message, index));
+
+  const rawTask = options?.task && typeof options.task === "object" ? options.task : null;
+  const linkedWorkflowRuns = (Array.isArray(rawTask?.workflowRuns) ? rawTask.workflowRuns : [])
+    .slice(0, Math.max(1, Number(options?.workflowRunLimit) || 6))
+    .map((run) => normalizeDiagnosticsWorkflowRun(run));
+
+  const linkedTask = rawTask
+    ? {
+        id: pickString(rawTask.id, rawTask.taskId),
+        title: pickString(rawTask.title, rawTask.taskTitle),
+        status: pickString(rawTask.status),
+        branch: pickString(rawTask.branch, rawTask.branchName),
+        repository: pickString(rawTask.repository, rawTask.repo),
+        workspace: pickString(rawTask.workspace, rawTask.meta?.workspace),
+        worktreePath: pickString(rawTask.worktreePath, rawTask.meta?.worktreePath),
+        primarySessionId: pickString(rawTask.primarySessionId, rawTask.sessionId, rawTask.meta?.primarySessionId),
+        linkedSessionIds: Array.isArray(rawTask.linkedSessionIds)
+          ? rawTask.linkedSessionIds.map((value) => String(value || "").trim()).filter(Boolean)
+          : Array.isArray(rawTask.meta?.linkedSessionIds)
+            ? rawTask.meta.linkedSessionIds.map((value) => String(value || "").trim()).filter(Boolean)
+            : [],
+      }
+    : null;
+
+  return {
+    schemaVersion: 1,
+    exportedAt,
+    session: {
+      id: pickString(session?.id, session?.sessionId),
+      taskId: pickString(session?.taskId),
+      title: pickString(session?.title, session?.taskTitle),
+      type: pickString(session?.type) || "session",
+      status: pickString(session?.status) || "unknown",
+      lifecycleStatus: pickString(session?.lifecycleStatus, session?.status),
+      runtimeState: pickString(session?.runtimeState, session?.status),
+      runtimeIsLive:
+        session?.runtimeIsLive === true
+        || String(session?.runtimeState || "").trim().toLowerCase() === "running"
+        || String(session?.lifecycleStatus || session?.status || "").trim().toLowerCase() === "active",
+      recommendation: pickString(session?.recommendation),
+      createdAt: toIsoString(session?.createdAt || session?.startedAt),
+      lastActiveAt: toIsoString(session?.lastActiveAt || session?.runtimeUpdatedAt || session?.updatedAt),
+      elapsedMs: toPositiveNumber(session?.elapsedMs),
+      idleMs: toPositiveNumber(session?.idleMs),
+      totalEvents: toPositiveNumber(session?.totalEvents) || 0,
+      turnCount: toPositiveNumber(session?.turnCount) || turns.length,
+      branch: pickString(session?.branch, session?.metadata?.branch),
+      workflowId: pickString(session?.workflowId, session?.metadata?.workflowId),
+      workflowName: pickString(session?.workflowName, session?.metadata?.workflowName),
+      workspaceId: pickString(session?.workspaceId, session?.metadata?.workspaceId),
+      workspaceDir: pickString(session?.workspaceDir, session?.metadata?.workspaceDir),
+      workspaceRoot: pickString(session?.workspaceRoot, session?.metadata?.workspaceRoot),
+      agentId: pickString(session?.agentId, session?.metadata?.agentId, session?.metadata?.agent),
+      tokenUsage,
+      contextWindow,
+    },
+    insights: {
+      totals: insights?.totals || null,
+      fileCounts: insights?.fileCounts || null,
+      topTools: Array.isArray(insights?.topTools) ? insights.topTools : [],
+      recentActions: Array.isArray(insights?.recentActions) ? insights.recentActions : [],
+      activityDiff: insights?.activityDiff || null,
+      contextBreakdown: Array.isArray(insights?.contextBreakdown) ? insights.contextBreakdown : [],
+    },
+    transcript: {
+      recentTurns: turns,
+      recentMessages,
+    },
+    linked: {
+      task: linkedTask,
+      workflowRuns: linkedWorkflowRuns,
+    },
   };
 }

--- a/server/ui-server.mjs
+++ b/server/ui-server.mjs
@@ -2767,6 +2767,32 @@ async function collectTaskLogDiagnostics(task, workspaceDir = "", limit = 8) {
   });
 }
 
+async function buildSessionLinkedTaskContext(session, reqUrl) {
+  const taskId = String(session?.taskId || "").trim();
+  const sessionId = String(session?.id || session?.sessionId || "").trim();
+  if (!taskId || taskId === sessionId) return null;
+
+  const adapter = getKanbanAdapter();
+  const task = await Promise.resolve(adapter?.getTask?.(taskId)).catch(() => null);
+  if (!task) return null;
+
+  const enriched = await applySharedStateToTasks([task]).catch(() => [task]);
+  let detailTask = enriched[0] || task;
+  const tracker = getSessionTracker();
+  const workflowRuns = await collectWorkflowRunsForTask(detailTask.id || taskId, reqUrl, 12).catch(() => []);
+  const mergedWorkflowRuns = mergeTaskWorkflowRuns(detailTask.workflowRuns, workflowRuns, 20);
+  detailTask.workflowRuns = mergedWorkflowRuns;
+
+  const linkedSessionIds = collectTaskLinkedSessionIds(detailTask, tracker);
+  const primarySessionId = linkedSessionIds[0] || null;
+  const linkedWorktreePath = await resolveTaskLinkedWorktreePath(detailTask, tracker).catch(() => null);
+  if (primarySessionId && !detailTask.primarySessionId) detailTask.primarySessionId = primarySessionId;
+  if (linkedWorktreePath) detailTask.worktreePath = linkedWorktreePath;
+  detailTask.linkedSessionIds = linkedSessionIds;
+  detailTask = withTaskRuntimeSnapshot(detailTask);
+  return detailTask;
+}
+
 async function buildTaskBlockedContext(task, options = {}) {
   const currentTask = task && typeof task === "object" ? task : {};
   const canStart = options.canStart && typeof options.canStart === "object"
@@ -26862,6 +26888,26 @@ if (path === "/api/agent-logs/context") {
             pagination: { total, offset, limit, hasMore: offset > 0 },
           });
         }
+      } catch (err) {
+        jsonResponse(res, 500, { ok: false, error: err.message });
+      }
+      return;
+    }
+
+    if (action === "diagnostics" && req.method === "GET") {
+      try {
+        const session = getScopedSessionRecord({ includeMessages: true });
+        if (!session) {
+          jsonResponse(res, 404, { ok: false, error: "Session not found" });
+          return;
+        }
+        const { buildSessionDiagnosticsBundle } = await import("../lib/session-insights.mjs");
+        const linkedTask = await buildSessionLinkedTaskContext(session, url).catch(() => null);
+        const data = buildSessionDiagnosticsBundle(session, {
+          exportedAt: new Date().toISOString(),
+          task: linkedTask,
+        });
+        jsonResponse(res, 200, { ok: true, data });
       } catch (err) {
         jsonResponse(res, 500, { ok: false, error: err.message });
       }

--- a/site/ui/modules/session-insights.js
+++ b/site/ui/modules/session-insights.js
@@ -1,4 +1,5 @@
 export {
+  buildSessionDiagnosticsBundle,
   buildSessionInsights,
   formatCompactCount,
 } from "../../lib/session-insights.mjs";

--- a/site/ui/tabs/agents.js
+++ b/site/ui/tabs/agents.js
@@ -39,8 +39,8 @@ import {
 } from "../components/workspace-switcher.js";
 import { ICONS } from "../modules/icons.js";
 import { formatCompactCount } from "../modules/session-insights.js";
-import { formatRelative, truncate } from "../modules/utils.js";
-import { getSessionRuntimeState, resolveSessionWorkspaceHint } from "../modules/session-api.js";
+import { downloadFile, formatRelative, truncate } from "../modules/utils.js";
+import { buildSessionApiPath, getSessionRuntimeState, resolveSessionWorkspaceHint } from "../modules/session-api.js";
 import {
   Card,
   Badge,
@@ -2916,9 +2916,25 @@ function FleetSessionsPanel({ slots, sessions = [], taskFallbackEntries = [], on
   const [sessionSearch, setSessionSearch] = useState("");
   const [selectedEntryKey, setSelectedEntryKey] = useState(null);
   const [copiedSessionId, setCopiedSessionId] = useState("");
+  const [sessionActionMenu, setSessionActionMenu] = useState({ anchorEl: null, sessionId: "" });
   const [logText, setLogText] = useState("(no logs yet)");
   const logRef = useRef(null);
   const allSessions = Array.isArray(sessions) ? sessions : [];
+  const sessionActionMenuOpen = Boolean(sessionActionMenu?.anchorEl && sessionActionMenu?.sessionId);
+
+  const closeSessionActionMenu = () => {
+    setSessionActionMenu({ anchorEl: null, sessionId: "" });
+  };
+
+  const openSessionActionMenu = (event, sessionId) => {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    if (!sessionId) return;
+    setSessionActionMenu({
+      anchorEl: event?.currentTarget || null,
+      sessionId,
+    });
+  };
 
   const copySessionId = (sessionId) => {
     if (!sessionId) return;
@@ -2939,6 +2955,52 @@ function FleetSessionsPanel({ slots, sessions = [], taskFallbackEntries = [], on
     } catch (_err) {
       setCopiedSessionId("");
       showToast("Copy failed", "error");
+    }
+  };
+
+  const fetchSessionDiagnostics = async (sessionId) => {
+    const sessionRecord = allSessions.find((entry) => entry?.id === sessionId) || null;
+    const diagnosticsPath = buildSessionApiPath(sessionId, "diagnostics", {
+      workspace: resolveSessionWorkspaceHint(sessionRecord, "all") || "all",
+    });
+    if (!diagnosticsPath) {
+      throw new Error("Session diagnostics path unavailable");
+    }
+    const response = await apiFetch(diagnosticsPath, { _silent: true });
+    return response?.data || null;
+  };
+
+  const handleCopyDiagnostics = async (sessionId) => {
+    closeSessionActionMenu();
+    if (!sessionId) return;
+    if (!navigator?.clipboard?.writeText) {
+      showToast("Clipboard unavailable", "error");
+      return;
+    }
+    try {
+      const diagnostics = await fetchSessionDiagnostics(sessionId);
+      if (!diagnostics) throw new Error("Session diagnostics unavailable");
+      await navigator.clipboard.writeText(JSON.stringify(diagnostics, null, 2));
+      showToast("Session diagnostics copied", "success");
+    } catch (err) {
+      showToast(`Diagnostics export failed: ${err?.message || err}`, "error");
+    }
+  };
+
+  const handleDownloadDiagnostics = async (sessionId) => {
+    closeSessionActionMenu();
+    if (!sessionId) return;
+    try {
+      const diagnostics = await fetchSessionDiagnostics(sessionId);
+      if (!diagnostics) throw new Error("Session diagnostics unavailable");
+      downloadFile(
+        JSON.stringify(diagnostics, null, 2),
+        `session-diagnostics-${sessionId}.json`,
+        "application/json",
+      );
+      showToast("Session diagnostics saved", "success");
+    } catch (err) {
+      showToast(`Diagnostics export failed: ${err?.message || err}`, "error");
     }
   };
 
@@ -3242,7 +3304,10 @@ function FleetSessionsPanel({ slots, sessions = [], taskFallbackEntries = [], on
                               data-session-id=${sessionId}
                               data-copied=${copiedSessionId === sessionId ? "true" : "false"}
                               aria-label=${`Copy session ID ${sessionId}`}
-                              onClick=${() => copySessionId(sessionId)}
+                              aria-controls=${sessionActionMenuOpen ? "fleet-session-action-menu" : undefined}
+                              aria-haspopup="menu"
+                              aria-expanded=${sessionActionMenuOpen ? "true" : undefined}
+                              onClick=${(event) => openSessionActionMenu(event, sessionId)}
                               onAnimationEnd=${(event) => {
                                 if (event?.target !== event?.currentTarget) return;
                                 if (copiedSessionId === sessionId) setCopiedSessionId("");
@@ -3262,6 +3327,25 @@ function FleetSessionsPanel({ slots, sessions = [], taskFallbackEntries = [], on
                   `;
                 })}`}
           </div>
+          <${Menu}
+            id="fleet-session-action-menu"
+            anchorEl=${sessionActionMenu?.anchorEl}
+            open=${sessionActionMenuOpen}
+            onClose=${closeSessionActionMenu}
+          >
+            <${MenuItem} onClick=${() => {
+              copySessionId(sessionActionMenu.sessionId);
+              closeSessionActionMenu();
+            }}>
+              Copy Session ID
+            </${MenuItem}>
+            <${MenuItem} onClick=${() => handleCopyDiagnostics(sessionActionMenu.sessionId)}>
+              Copy Diagnostics
+            </${MenuItem}>
+            <${MenuItem} onClick=${() => handleDownloadDiagnostics(sessionActionMenu.sessionId)}>
+              Download Diagnostics
+            </${MenuItem}>
+          </${Menu}>
         </div>
         <div class="session-detail fleet-session-detail">
           ${selectedEntry

--- a/tests/fleet-tab-render.test.mjs
+++ b/tests/fleet-tab-render.test.mjs
@@ -64,7 +64,8 @@ for (const { relPath, source } of sourceFiles) {
       expect(source).toContain("aria-label=${`Copy session ID ${sessionId}`}");
       expect(source).toContain("data-copied=${copiedSessionId === sessionId ? \"true\" : \"false\"}");
       expect(source).toContain("sessionId.slice(0, 8)");
-      expect(source).toContain("copySessionId(sessionId)");
+      expect(source).toContain("openSessionActionMenu(event, sessionId)");
+      expect(source).toContain("Copy Session ID");
       expect(source).toContain("fleet-session-id-pill-icon");
       expect(source).toContain('copiedSessionId === sessionId ? "✓" : ICONS.copy');
     });

--- a/tests/session-api.test.mjs
+++ b/tests/session-api.test.mjs
@@ -24,6 +24,11 @@ describe("session api workspace routing", () => {
     expect(path).toBe("/api/sessions/abc123?workspace=all");
   });
 
+  it("builds diagnostics action paths with explicit workspace scope", () => {
+    const path = buildSessionApiPath("abc123", "diagnostics", { workspace: "*" });
+    expect(path).toBe("/api/sessions/abc123/diagnostics?workspace=all");
+  });
+
   it("normalizes wildcard workspace hints to all", () => {
     const path = buildSessionApiPath("abc123", "message", { workspace: "*" });
     expect(path).toBe("/api/sessions/abc123/message?workspace=all");
@@ -342,5 +347,4 @@ describe("session lifecycle/runtime metadata", () => {
     ).toBe("2026-01-02T00:00:00.000Z");
   });
 });
-
 

--- a/tests/session-insights.test.mjs
+++ b/tests/session-insights.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildSessionInsights } from "../ui/modules/session-insights.js";
+import { buildSessionDiagnosticsBundle, buildSessionInsights } from "../ui/modules/session-insights.js";
 
 describe("session-insights", () => {
   it("tracks tool/file counters from tool call history", () => {
@@ -121,5 +121,124 @@ describe("session-insights", () => {
     expect(insights.contextWindow.percent).toBe(44.1);
     expect(insights.recentActions).toHaveLength(1);
     expect(insights.activityDiff.totalFiles).toBe(1);
+  });
+
+  it("builds a compact diagnostics export bundle with linked workflow context", () => {
+    const session = {
+      id: "session-diagnostics-1",
+      taskId: "TASK-101",
+      title: "Diagnose agent stall",
+      status: "active",
+      lifecycleStatus: "active",
+      runtimeState: "running",
+      type: "task",
+      totalEvents: 18,
+      createdAt: "2026-03-04T00:58:00.000Z",
+      lastActiveAt: "2026-03-04T01:00:10.000Z",
+      elapsedMs: 130000,
+      idleMs: 4000,
+      workspaceDir: "/repo/worktrees/task-101",
+      workspaceRoot: "/repo",
+      branch: "task/TASK-101-diagnostics",
+      metadata: {
+        agentId: "agent-17",
+        workflowId: "wf-diagnostics",
+        workflowName: "Agent Diagnostics",
+      },
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          summary: "Collected telemetry and paused for input.",
+          startedAt: "2026-03-04T00:58:10.000Z",
+          endedAt: "2026-03-04T00:58:45.000Z",
+          durationMs: 35000,
+          tokenUsage: {
+            inputTokens: 900,
+            outputTokens: 240,
+            totalTokens: 1140,
+          },
+        },
+      ],
+      messages: [
+        {
+          type: "system",
+          role: "system",
+          content: "Context Window\n103.2K / 272K tokens • 38%\nMessages 4.2%",
+          timestamp: "2026-03-04T00:58:00.000Z",
+        },
+        {
+          type: "user",
+          role: "user",
+          content: "Export diagnostics for this session.",
+          timestamp: "2026-03-04T00:59:00.000Z",
+        },
+        {
+          type: "tool_call",
+          content: "read_file(src/ui/app.js)",
+          meta: { toolName: "read_file" },
+          timestamp: "2026-03-04T00:59:10.000Z",
+        },
+        {
+          type: "agent_message",
+          role: "assistant",
+          content: "I gathered the linked workflow state.",
+          timestamp: "2026-03-04T01:00:00.000Z",
+          meta: {
+            usage: {
+              input_tokens: 1200,
+              output_tokens: 300,
+              total_tokens: 1500,
+            },
+          },
+        },
+      ],
+    };
+
+    const bundle = buildSessionDiagnosticsBundle(session, {
+      exportedAt: "2026-03-04T01:00:30.000Z",
+      task: {
+        id: "TASK-101",
+        title: "Investigate stalled agent",
+        status: "inprogress",
+        branch: "task/TASK-101-diagnostics",
+        repository: "bosun",
+        worktreePath: "/repo/worktrees/task-101",
+        primarySessionId: "session-diagnostics-1",
+        linkedSessionIds: ["session-diagnostics-1", "session-shadow-2"],
+        workflowRuns: [
+          {
+            runId: "run-17",
+            workflowId: "wf-diagnostics",
+            status: "completed",
+            startedAt: "2026-03-04T00:58:05.000Z",
+            endedAt: "2026-03-04T00:59:55.000Z",
+            primarySessionId: "session-diagnostics-1",
+            issueAdvisor: {
+              recommendedAction: "resume_remaining",
+              summary: "Resume from Agent Plan.",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(bundle.schemaVersion).toBe(1);
+    expect(bundle.session.id).toBe("session-diagnostics-1");
+    expect(bundle.session.workflowId).toBe("wf-diagnostics");
+    expect(bundle.session.tokenUsage.totalTokens).toBe(1500);
+    expect(bundle.session.contextWindow.usedTokens).toBe(103200);
+    expect(bundle.transcript.recentTurns).toHaveLength(1);
+    expect(bundle.transcript.recentTurns[0].totalTokens).toBe(1140);
+    expect(bundle.transcript.recentMessages[0].content).toBe("Export diagnostics for this session.");
+    expect(bundle.linked.task.id).toBe("TASK-101");
+    expect(bundle.linked.task.linkedSessionIds).toContain("session-shadow-2");
+    expect(bundle.linked.workflowRuns[0]).toMatchObject({
+      runId: "run-17",
+      workflowId: "wf-diagnostics",
+      issueAdvisor: {
+        recommendedAction: "resume_remaining",
+      },
+    });
   });
 });

--- a/tests/ui-agents-session-pill.test.mjs
+++ b/tests/ui-agents-session-pill.test.mjs
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const sourceFiles = [
+  "ui/tabs/agents.js",
+  "site/ui/tabs/agents.js",
+].map((relPath) => ({
+  relPath,
+  source: readFileSync(resolve(process.cwd(), relPath), "utf8"),
+}));
+
+for (const { relPath, source } of sourceFiles) {
+  describe(`agents session pill diagnostics actions (${relPath})`, () => {
+    it("opens a session action menu from the existing pill entrypoint", () => {
+      expect(source).toContain("fleet-session-id-pill");
+      expect(source).toContain("setSessionActionMenu");
+      expect(source).toContain("aria-controls=${sessionActionMenuOpen ? \"fleet-session-action-menu\" : undefined}");
+      expect(source).toContain("aria-haspopup=\"menu\"");
+      expect(source).toContain("aria-expanded=${sessionActionMenuOpen ? \"true\" : undefined}");
+      expect(source).toContain("openSessionActionMenu(event, sessionId)");
+      expect(source).not.toContain("onClick=${() => copySessionId(sessionId)}");
+    });
+
+    it("offers copy-id and diagnostics export actions with visible failure handling", () => {
+      expect(source).toContain("Copy Session ID");
+      expect(source).toContain("Copy Diagnostics");
+      expect(source).toContain("Download Diagnostics");
+      expect(source).toContain("Session diagnostics copied");
+      expect(source).toContain("Session diagnostics saved");
+      expect(source).toContain("Diagnostics export failed");
+      expect(source).toContain("session-diagnostics-${sessionId}.json");
+      expect(source).toContain("buildSessionApiPath(sessionId, \"diagnostics\"");
+    });
+  });
+}

--- a/tests/ui-server-session-actions.test.mjs
+++ b/tests/ui-server-session-actions.test.mjs
@@ -78,4 +78,83 @@ describe("ui-server session actions", () => {
     ).then((response) => response.json());
     expect(resumedSession.session?.status).toBe("active");
   }, 15000);
+
+  it("exports a diagnostics bundle for the requested session", async () => {
+    const mod = await import("../server/ui-server.mjs");
+    const { _resetSingleton, getSessionTracker } = await import("../infra/session-tracker.mjs");
+    _resetSingleton({ persistDir: null });
+    const taskStore = await import("../task/task-store.mjs");
+    const server = await mod.startTelegramUiServer({
+      port: 0,
+      host: "127.0.0.1",
+      skipInstanceLock: true,
+      skipAutoOpen: true,
+    });
+    const port = server.address().port;
+    const baseUrl = String(mod.getTelegramUiUrl() || `http://127.0.0.1:${port}`).trim();
+    if (baseUrl.startsWith("https://")) {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    }
+    const apiUrl = (path) => new URL(path, `${baseUrl}/`).toString();
+
+    taskStore.createTask({
+      id: "TASK-DIAG-1",
+      title: "Diagnostics export",
+      status: "inprogress",
+      branch: "task/TASK-DIAG-1-export",
+      workflowRuns: [
+        {
+          runId: "run-diag-1",
+          workflowId: "wf-diag-1",
+          status: "completed",
+          primarySessionId: "session-diag-1",
+          issueAdvisor: {
+            recommendedAction: "resume_remaining",
+            summary: "Resume from Agent Plan.",
+          },
+        },
+      ],
+    });
+    await taskStore.waitForStoreWrites();
+
+    const tracker = getSessionTracker();
+    tracker.createSession({
+      id: "session-diag-1",
+      type: "task",
+      taskId: "TASK-DIAG-1",
+      metadata: {
+        title: "Diagnostics export",
+        workflowId: "wf-diag-1",
+        workflowName: "Diagnostics Flow",
+        branch: "task/TASK-DIAG-1-export",
+      },
+    });
+    tracker.appendEvent("session-diag-1", {
+      role: "assistant",
+      type: "agent_message",
+      content: "Collected diagnostics context.",
+      timestamp: "2026-03-04T01:00:00.000Z",
+      meta: {
+        usage: {
+          input_tokens: 1000,
+          output_tokens: 250,
+          total_tokens: 1250,
+        },
+      },
+    });
+
+    const diagnostics = await fetch(
+      apiUrl("/api/sessions/session-diag-1/diagnostics?workspace=all"),
+    ).then((response) => response.json());
+
+    expect(diagnostics.ok).toBe(true);
+    expect(diagnostics.data?.schemaVersion).toBe(1);
+    expect(diagnostics.data?.session?.id).toBe("session-diag-1");
+    expect(diagnostics.data?.session?.tokenUsage?.totalTokens).toBe(1250);
+    expect(diagnostics.data?.linked?.task?.id).toBe("TASK-DIAG-1");
+    expect(diagnostics.data?.linked?.workflowRuns?.[0]).toMatchObject({
+      runId: "run-diag-1",
+      workflowId: "wf-diag-1",
+    });
+  }, 15000);
 });

--- a/ui/modules/session-insights.js
+++ b/ui/modules/session-insights.js
@@ -1,4 +1,5 @@
 export {
+  buildSessionDiagnosticsBundle,
   buildSessionInsights,
   formatCompactCount,
 } from "../../lib/session-insights.mjs";

--- a/ui/tabs/agents.js
+++ b/ui/tabs/agents.js
@@ -39,8 +39,8 @@ import {
 } from "../components/workspace-switcher.js";
 import { ICONS } from "../modules/icons.js";
 import { formatCompactCount } from "../modules/session-insights.js";
-import { formatRelative, truncate } from "../modules/utils.js";
-import { getSessionRuntimeState, resolveSessionWorkspaceHint } from "../modules/session-api.js";
+import { downloadFile, formatRelative, truncate } from "../modules/utils.js";
+import { buildSessionApiPath, getSessionRuntimeState, resolveSessionWorkspaceHint } from "../modules/session-api.js";
 import {
   Card,
   Badge,
@@ -2912,9 +2912,25 @@ function FleetSessionsPanel({ slots, sessions = [], taskFallbackEntries = [], on
   const [sessionSearch, setSessionSearch] = useState("");
   const [selectedEntryKey, setSelectedEntryKey] = useState(null);
   const [copiedSessionId, setCopiedSessionId] = useState("");
+  const [sessionActionMenu, setSessionActionMenu] = useState({ anchorEl: null, sessionId: "" });
   const [logText, setLogText] = useState("(no logs yet)");
   const logRef = useRef(null);
   const allSessions = Array.isArray(sessions) ? sessions : [];
+  const sessionActionMenuOpen = Boolean(sessionActionMenu?.anchorEl && sessionActionMenu?.sessionId);
+
+  const closeSessionActionMenu = () => {
+    setSessionActionMenu({ anchorEl: null, sessionId: "" });
+  };
+
+  const openSessionActionMenu = (event, sessionId) => {
+    event?.preventDefault?.();
+    event?.stopPropagation?.();
+    if (!sessionId) return;
+    setSessionActionMenu({
+      anchorEl: event?.currentTarget || null,
+      sessionId,
+    });
+  };
 
   const copySessionId = (sessionId) => {
     if (!sessionId) return;
@@ -2935,6 +2951,52 @@ function FleetSessionsPanel({ slots, sessions = [], taskFallbackEntries = [], on
     } catch (_err) {
       setCopiedSessionId("");
       showToast("Copy failed", "error");
+    }
+  };
+
+  const fetchSessionDiagnostics = async (sessionId) => {
+    const sessionRecord = allSessions.find((entry) => entry?.id === sessionId) || null;
+    const diagnosticsPath = buildSessionApiPath(sessionId, "diagnostics", {
+      workspace: resolveSessionWorkspaceHint(sessionRecord, "all") || "all",
+    });
+    if (!diagnosticsPath) {
+      throw new Error("Session diagnostics path unavailable");
+    }
+    const response = await apiFetch(diagnosticsPath, { _silent: true });
+    return response?.data || null;
+  };
+
+  const handleCopyDiagnostics = async (sessionId) => {
+    closeSessionActionMenu();
+    if (!sessionId) return;
+    if (!navigator?.clipboard?.writeText) {
+      showToast("Clipboard unavailable", "error");
+      return;
+    }
+    try {
+      const diagnostics = await fetchSessionDiagnostics(sessionId);
+      if (!diagnostics) throw new Error("Session diagnostics unavailable");
+      await navigator.clipboard.writeText(JSON.stringify(diagnostics, null, 2));
+      showToast("Session diagnostics copied", "success");
+    } catch (err) {
+      showToast(`Diagnostics export failed: ${err?.message || err}`, "error");
+    }
+  };
+
+  const handleDownloadDiagnostics = async (sessionId) => {
+    closeSessionActionMenu();
+    if (!sessionId) return;
+    try {
+      const diagnostics = await fetchSessionDiagnostics(sessionId);
+      if (!diagnostics) throw new Error("Session diagnostics unavailable");
+      downloadFile(
+        JSON.stringify(diagnostics, null, 2),
+        `session-diagnostics-${sessionId}.json`,
+        "application/json",
+      );
+      showToast("Session diagnostics saved", "success");
+    } catch (err) {
+      showToast(`Diagnostics export failed: ${err?.message || err}`, "error");
     }
   };
 
@@ -3238,7 +3300,10 @@ function FleetSessionsPanel({ slots, sessions = [], taskFallbackEntries = [], on
                               data-session-id=${sessionId}
                               data-copied=${copiedSessionId === sessionId ? "true" : "false"}
                               aria-label=${`Copy session ID ${sessionId}`}
-                              onClick=${() => copySessionId(sessionId)}
+                              aria-controls=${sessionActionMenuOpen ? "fleet-session-action-menu" : undefined}
+                              aria-haspopup="menu"
+                              aria-expanded=${sessionActionMenuOpen ? "true" : undefined}
+                              onClick=${(event) => openSessionActionMenu(event, sessionId)}
                               onAnimationEnd=${(event) => {
                                 if (event?.target !== event?.currentTarget) return;
                                 if (copiedSessionId === sessionId) setCopiedSessionId("");
@@ -3258,6 +3323,25 @@ function FleetSessionsPanel({ slots, sessions = [], taskFallbackEntries = [], on
                   `;
                 })}`}
           </div>
+          <${Menu}
+            id="fleet-session-action-menu"
+            anchorEl=${sessionActionMenu?.anchorEl}
+            open=${sessionActionMenuOpen}
+            onClose=${closeSessionActionMenu}
+          >
+            <${MenuItem} onClick=${() => {
+              copySessionId(sessionActionMenu.sessionId);
+              closeSessionActionMenu();
+            }}>
+              Copy Session ID
+            </${MenuItem}>
+            <${MenuItem} onClick=${() => handleCopyDiagnostics(sessionActionMenu.sessionId)}>
+              Copy Diagnostics
+            </${MenuItem}>
+            <${MenuItem} onClick=${() => handleDownloadDiagnostics(sessionActionMenu.sessionId)}>
+              Download Diagnostics
+            </${MenuItem}>
+          </${Menu}>
         </div>
         <div class="session-detail fleet-session-detail">
           ${selectedEntry


### PR DESCRIPTION
## Summary
- add a compact session diagnostics bundle builder that combines session insights with linked task and workflow context
- expose `/api/sessions/:id/diagnostics` and wire the Agents session pill menu to copy or download diagnostics exports
- cover the new diagnostics export path with UI, API, and insights regression tests

## Validation
- npm test
- npm run build
- npm run lint