### PR TITLE
[codex] merge imported task snapshots and refresh diagnostics defaults

### DIFF
--- a/server/ui-server.mjs
+++ b/server/ui-server.mjs
@@ -3041,6 +3041,8 @@ async function collectTaskLogDiagnostics(task, workspaceDir = "", limit = 8) {
     pushLogPath(resolve(workspaceDir, ".bosun", "logs", "monitor-error.log"));
     pushLogPath(resolve(workspaceDir, ".bosun", "logs", "monitor.log"));
   }
+  pushLogPath(resolve(process.cwd(), ".bosun", "logs", "monitor-error.log"));
+  pushLogPath(resolve(process.cwd(), ".bosun", "logs", "monitor.log"));
   pushLogPath(resolve(repoRoot, ".bosun", "logs", "monitor-error.log"));
   pushLogPath(resolve(repoRoot, ".bosun", "logs", "monitor.log"));
 
@@ -5254,10 +5256,103 @@ function extractImportedTaskList(body = null) {
   return null;
 }
 
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeImportedTaskCollection(baseEntries = [], incomingEntries = [], keyBuilder) {
+  const merged = [];
+  const indexByKey = new Map();
+  const appendEntry = (entry) => {
+    if (!entry || typeof entry !== "object") return;
+    const key = typeof keyBuilder === "function" ? String(keyBuilder(entry) || "").trim() : "";
+    if (key && indexByKey.has(key)) {
+      merged[indexByKey.get(key)] = { ...merged[indexByKey.get(key)], ...entry };
+      return;
+    }
+    merged.push(entry);
+    if (key) indexByKey.set(key, merged.length - 1);
+  };
+  for (const entry of Array.isArray(baseEntries) ? baseEntries : []) appendEntry(entry);
+  for (const entry of Array.isArray(incomingEntries) ? incomingEntries : []) appendEntry(entry);
+  return merged;
+}
+
+function mergeImportedTaskTimeline(baseEntries = [], incomingEntries = []) {
+  return mergeImportedTaskCollection(baseEntries, incomingEntries, (entry) => (
+    entry?.id
+      || [
+        entry?.type,
+        entry?.source,
+        entry?.at,
+        entry?.status,
+        entry?.fromStatus,
+        entry?.toStatus,
+        entry?.message,
+      ].map((value) => String(value || "").trim()).join("|")
+  ));
+}
+
+function mergeImportedTaskStatusHistory(baseEntries = [], incomingEntries = []) {
+  return mergeImportedTaskCollection(baseEntries, incomingEntries, (entry) => [
+    entry?.status,
+    entry?.timestamp,
+    entry?.source,
+  ].map((value) => String(value || "").trim()).join("|"));
+}
+
+function mergeImportedTaskMeta(currentMeta = {}, incomingMeta = {}) {
+  const base = isPlainObject(currentMeta) ? currentMeta : {};
+  const incoming = isPlainObject(incomingMeta) ? incomingMeta : {};
+  const merged = { ...base };
+  for (const [key, value] of Object.entries(incoming)) {
+    if (isPlainObject(value) && isPlainObject(base[key])) {
+      merged[key] = mergeImportedTaskMeta(base[key], value);
+    } else {
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+function buildImportedTaskPatch(currentTask = {}, importedTask = {}, mode = "merge") {
+  const patch = importedTask && typeof importedTask === "object" ? { ...importedTask } : {};
+  if (mode !== "merge") return patch;
+
+  if (Object.prototype.hasOwnProperty.call(importedTask, "workflowRuns")
+      && Array.isArray(importedTask.workflowRuns)) {
+    patch.workflowRuns = mergeTaskWorkflowRuns(
+      Array.isArray(currentTask?.workflowRuns) ? currentTask.workflowRuns : [],
+      importedTask.workflowRuns,
+      200,
+    );
+  }
+  if (Object.prototype.hasOwnProperty.call(importedTask, "timeline")
+      && Array.isArray(importedTask.timeline)) {
+    patch.timeline = mergeImportedTaskTimeline(
+      Array.isArray(currentTask?.timeline) ? currentTask.timeline : [],
+      importedTask.timeline,
+    );
+  }
+  if (Object.prototype.hasOwnProperty.call(importedTask, "statusHistory")
+      && Array.isArray(importedTask.statusHistory)) {
+    patch.statusHistory = mergeImportedTaskStatusHistory(
+      Array.isArray(currentTask?.statusHistory) ? currentTask.statusHistory : [],
+      importedTask.statusHistory,
+    );
+  }
+  if (Object.prototype.hasOwnProperty.call(importedTask, "meta")
+      && isPlainObject(importedTask.meta)) {
+    patch.meta = mergeImportedTaskMeta(currentTask?.meta, importedTask.meta);
+  }
+  return patch;
+}
+
 async function importInternalTaskStateSnapshot(body = {}) {
   const taskStore = await ensureTaskStoreApi();
   const addTaskFn = typeof taskStore?.addTask === "function" ? taskStore.addTask : null;
   const updateTaskFn = typeof taskStore?.updateTask === "function" ? taskStore.updateTask : null;
+  const getTaskFn = typeof taskStore?.getTask === "function" ? taskStore.getTask : null;
   if (!addTaskFn || !updateTaskFn) {
     throw new Error("Internal task store import is unavailable");
   }
@@ -5301,12 +5396,19 @@ async function importInternalTaskStateSnapshot(body = {}) {
 
     try {
       if (existingById.has(taskId)) {
-        updateTaskFn(taskId, task);
+        const currentTask = existingById.get(taskId) || {};
+        const patch = buildImportedTaskPatch(currentTask, task, mode);
+        updateTaskFn(taskId, patch);
+        if (getTaskFn) {
+          existingById.set(taskId, getTaskFn(taskId) || { ...currentTask, ...patch });
+        } else {
+          existingById.set(taskId, { ...currentTask, ...patch });
+        }
         summary.updated += 1;
         results.push({ id: taskId, status: "updated" });
       } else {
         addTaskFn(task);
-        existingById.set(taskId, task);
+        existingById.set(taskId, getTaskFn ? (getTaskFn(taskId) || task) : task);
         summary.created += 1;
         results.push({ id: taskId, status: "created" });
       }

--- a/tests/ui-server.test.mjs
+++ b/tests/ui-server.test.mjs
@@ -2843,6 +2843,10 @@ describeUiServer("ui-server mini app", () => {
   it("imports task state snapshots with merge semantics via mini app API", async () => {
     const mod = await import("../server/ui-server.mjs");
     const taskStore = await import("../task/task-store.mjs");
+    const existingTimelineAt = new Date("2026-04-29T10:00:00.000Z").toISOString();
+    const importedTimelineAt = new Date("2026-04-29T11:00:00.000Z").toISOString();
+    const existingStatusAt = new Date("2026-04-29T10:05:00.000Z").toISOString();
+    const importedStatusAt = new Date("2026-04-29T11:05:00.000Z").toISOString();
 
     const server = await mod.startTelegramUiServer({
       port: await getFreePort(),
@@ -2854,6 +2858,30 @@ describeUiServer("ui-server mini app", () => {
       id: "task-import-1",
       title: "Original title",
       status: "todo",
+      timeline: [{
+        id: "timeline-local-1",
+        type: "task.created",
+        source: "local",
+        at: existingTimelineAt,
+        message: "Existing timeline entry",
+      }],
+      workflowRuns: [{
+        runId: "run-local-1",
+        workflowId: "wf-local-1",
+        status: "running",
+        summary: "Existing workflow link",
+      }],
+      statusHistory: [{
+        status: "todo",
+        timestamp: existingStatusAt,
+        source: "local",
+      }],
+      meta: {
+        localOnly: true,
+        nested: {
+          keep: "local-value",
+        },
+      },
     });
     await taskStore.waitForStoreWrites();
 
@@ -2867,9 +2895,21 @@ describeUiServer("ui-server mini app", () => {
             id: "task-import-1",
             title: "Updated title",
             status: "inreview",
-            timeline: [{ type: "status.transition", source: "import" }],
+            timeline: [{
+              id: "timeline-import-1",
+              type: "status.transition",
+              source: "import",
+              at: importedTimelineAt,
+              message: "Imported timeline entry",
+            }],
             workflowRuns: [{ runId: "run-import-1", workflowId: "wf-import-1", status: "completed" }],
-            statusHistory: [{ status: "inreview", timestamp: new Date().toISOString(), source: "import" }],
+            statusHistory: [{ status: "inreview", timestamp: importedStatusAt, source: "import" }],
+            meta: {
+              importedOnly: true,
+              nested: {
+                imported: "import-value",
+              },
+            },
           },
           {
             id: "task-import-2",
@@ -2891,8 +2931,114 @@ describeUiServer("ui-server mini app", () => {
     expect(updatedTask?.title).toBe("Updated title");
     expect(updatedTask?.status).toBe("inreview");
     expect(Array.isArray(updatedTask?.workflowRuns)).toBe(true);
-    expect(updatedTask?.workflowRuns?.[0]?.runId).toBe("run-import-1");
+    expect(updatedTask?.workflowRuns?.map((run) => run.runId)).toEqual(
+      expect.arrayContaining(["run-local-1", "run-import-1"]),
+    );
+    expect(updatedTask?.timeline?.map((entry) => entry.id)).toEqual(
+      expect.arrayContaining(["timeline-local-1", "timeline-import-1"]),
+    );
+    expect(updatedTask?.statusHistory).toEqual(expect.arrayContaining([
+      expect.objectContaining({ status: "todo", source: "local" }),
+      expect.objectContaining({ status: "inreview", source: "import" }),
+    ]));
+    expect(updatedTask?.meta).toMatchObject({
+      localOnly: true,
+      importedOnly: true,
+      nested: {
+        keep: "local-value",
+        imported: "import-value",
+      },
+    });
     expect(createdTask?.title).toBe("Imported task");
+  }, 15000);
+
+  it("imports task state snapshots with upsert replace semantics via mini app API", async () => {
+    const mod = await import("../server/ui-server.mjs");
+    const taskStore = await import("../task/task-store.mjs");
+
+    const server = await mod.startTelegramUiServer({
+      port: await getFreePort(),
+      host: "127.0.0.1",
+    });
+    const port = server.address().port;
+
+    taskStore.addTask({
+      id: "task-import-upsert-1",
+      title: "Original title",
+      status: "todo",
+      timeline: [{
+        id: "timeline-local-upsert",
+        type: "task.created",
+        source: "local",
+      }],
+      workflowRuns: [{
+        runId: "run-local-upsert",
+        workflowId: "wf-local-upsert",
+        status: "running",
+      }],
+      statusHistory: [{
+        status: "todo",
+        timestamp: new Date("2026-04-29T09:00:00.000Z").toISOString(),
+        source: "local",
+      }],
+      meta: {
+        localOnly: true,
+      },
+    });
+    await taskStore.waitForStoreWrites();
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/tasks/import`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "upsert",
+        tasks: [
+          {
+            id: "task-import-upsert-1",
+            title: "Updated title",
+            status: "inreview",
+            timeline: [{
+              id: "timeline-import-upsert",
+              type: "status.transition",
+              source: "import",
+            }],
+            workflowRuns: [{
+              runId: "run-import-upsert",
+              workflowId: "wf-import-upsert",
+              status: "completed",
+            }],
+            statusHistory: [{
+              status: "inreview",
+              timestamp: new Date("2026-04-29T11:30:00.000Z").toISOString(),
+              source: "import",
+            }],
+            meta: {
+              importedOnly: true,
+            },
+          },
+        ],
+      }),
+    });
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.data.summary.created).toBe(0);
+    expect(json.data.summary.updated).toBe(1);
+
+    const updatedTask = taskStore.getTask("task-import-upsert-1");
+    expect(updatedTask?.title).toBe("Updated title");
+    expect(updatedTask?.timeline?.map((entry) => entry.id)).not.toContain("timeline-local-upsert");
+    expect(updatedTask?.timeline?.map((entry) => entry.id)).toContain("timeline-import-upsert");
+    expect(updatedTask?.workflowRuns?.map((run) => run.runId)).toEqual(["run-import-upsert"]);
+    expect(updatedTask?.statusHistory).toEqual(expect.arrayContaining([
+      expect.objectContaining({ status: "inreview", source: "import" }),
+    ]));
+    expect(updatedTask?.statusHistory).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ status: "todo", source: "local" }),
+    ]));
+    expect(updatedTask?.meta?.localOnly).toBeUndefined();
+    expect(updatedTask?.meta?.importedOnly).toBe(true);
   }, 15000);
 
   it("queues /plan commands in background to avoid request timeouts", async () => {


### PR DESCRIPTION
## What changed
- preserve existing imported-task state when `/api/tasks/import` updates an existing task in `merge` mode
- merge `workflowRuns`, `timeline`, `statusHistory`, and nested `meta` fields instead of replacing prior local data
- keep `upsert` behavior as full replacement and add coverage for both merge and replace semantics
- expand task diagnostics log discovery so the UI also checks the current worktree `.bosun/logs` paths

## Why
Imported task snapshots were overwriting previously collected local task state. That caused imported updates like the `task-import-1` "Updated title" case to drop existing workflow links, timeline entries, status history, and nested metadata even when the caller requested merge semantics.

## Impact
The Mini App import endpoint now preserves accumulated task history during merges while still allowing explicit replacement through `mode: "upsert"`. Task diagnostics are also more reliable in worktree-based runs.

## Root cause
The import path passed the incoming task object directly to `updateTask`, so array and object fields replaced the stored snapshot wholesale instead of being merged field-by-field.

## Validation
- `node tools/vitest-runner.mjs run --configLoader runner tests/ui-server.test.mjs`
- `npm test -- --configLoader runner`
- `npm run build`

## Notes
- `npm test -- --configLoader runner` still has unrelated failing suites in this worktree outside the touched area, but the pre-push targeted checks for this branch passed and included `tests/ui-server.test.mjs`.
