### PR TITLE
fix(workflow): route branch-local CI failures to PR repair

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -79,7 +79,7 @@ ADJACENCY_MAP=(
   ".githooks/pre-push|prepublish-check|vitest-runner"
   "workflow/|workflow-*|workflow-task-lifecycle*|workflow-write-file-encoding*|workflow-pipeline-primitives*|workflow-research-evidence-sidecar*|manual-flows*|mcp-workflow-adapter*|bosun-native-workflow-nodes*|meeting-workflow*|run-evaluator*|state-ledger-sqlite*|webhook-gateway*|credential-store*|cron-scheduler*"
   "workflow-templates/|workflow-templates*|workflow-new-templates*|workflow-engine*|manual-flows*"
-  "task/|task-*|workflow-task-lifecycle*|kanban-*|state-ledger-sqlite*|ve-orchestrator*|vk-api*|ve-kanban*"
+  "task/|task-*|workflow-engine*|workflow-task-lifecycle*|kanban-*|state-ledger-sqlite*|ve-orchestrator*|vk-api*|ve-kanban*"
   "kanban/|kanban-*|task-store*|task-claims*|ve-kanban*|ve-orchestrator*|vk-api*"
   "workspace/|workspace-*|shared-state*|worktree-*|worktree-recovery-regression*|sync-engine*"
   "infra/|monitor-*|heartbeat-monitor*|daemon-*|restart-*|startup-*|maintenance-*|anomaly-*|preflight*|tracing*|tui-bridge*|windows-hidden-child-processes*|weekly-agent-work-report*|workflow-task-lifecycle*|workflow-engine*|session-telemetry*"
@@ -393,11 +393,40 @@ is_deferred_local_suite() {
   is_isolated_project_suite "$1"
 }
 
+is_critical_deferred_suite() {
+  local test_file="$1"
+  case "$test_file" in
+    tests/workflow-engine.test.mjs|\
+    tests/workflow-task-lifecycle.test.mjs|\
+    tests/workflow-templates.test.mjs)
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  local changed_path normalized
+  for changed_path in "${CHANGED_FILES[@]}"; do
+    normalized="${changed_path//\\//}"
+    case "$normalized" in
+      workflow/*|\
+      workflow-templates/*|\
+      task/*|\
+      tests/workflow-engine.test.mjs|\
+      tests/workflow-task-lifecycle.test.mjs|\
+      tests/workflow-templates.test.mjs)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
 declare -a DEFERRED_LOCAL_TESTS=()
 if ! should_include_deferred_local_suites; then
   declare -a FILTERED_TARGET_TESTS=()
   for test_file in "${SORTED_TARGET_TESTS[@]}"; do
-    if is_deferred_local_suite "$test_file"; then
+    if is_deferred_local_suite "$test_file" && ! is_critical_deferred_suite "$test_file"; then
       DEFERRED_LOCAL_TESTS+=("$test_file")
       continue
     fi

--- a/tests/vitest-runner.test.mjs
+++ b/tests/vitest-runner.test.mjs
@@ -44,7 +44,7 @@ describe("vitest-runner", () => {
     expect(prePushHook).toContain('"infra/|monitor-*|heartbeat-monitor*|daemon-*|restart-*|startup-*|maintenance-*|anomaly-*|preflight*|tracing*|tui-bridge*|windows-hidden-child-processes*|weekly-agent-work-report*|workflow-task-lifecycle*|workflow-engine*|session-telemetry*"');
     expect(prePushHook).toContain('"agent/|agent-*|primary-agent*|fleet-*|review-agent*|analyze-agent*|autofix*|streaming-agent*|hook-library*|weekly-agent-work-report*|internal-harness*|harness-runtime*|harness-surface-integration*|provider-kernel*|provider-kernel-support*|session-manager*|tool-governance-support*|tool-orchestrator*"');
     expect(prePushHook).toContain('"telegram/|telegram-*|harness-surface-integration*|whatsapp-*|weekly-agent-work-report*|harness-surface-clients*"');
-    expect(prePushHook).toContain('"task/|task-*|workflow-task-lifecycle*|kanban-*|state-ledger-sqlite*|ve-orchestrator*|vk-api*|ve-kanban*"');
+    expect(prePushHook).toContain('"task/|task-*|workflow-engine*|workflow-task-lifecycle*|kanban-*|state-ledger-sqlite*|ve-orchestrator*|vk-api*|ve-kanban*"');
     expect(prePushHook).toContain('"lib/|logger*|log-tail*|utils*|library-*|error-detector*|context-*|codebase-audit*|repo-map*|state-ledger-sqlite*|hot-path-runtime*"');
   });
 
@@ -395,6 +395,9 @@ describe("vitest-runner", () => {
     expect(prePushHook).toContain('BOSUN_PREPUSH_RUN_PACKED_SMOKE');
     expect(prePushHook).toContain('BOSUN_PREPUSH_INCLUDE_HEAVY');
     expect(prePushHook).toContain('BOSUN_RUN_HEAVY_TESTS');
+    expect(prePushHook).toContain('is_critical_deferred_suite()');
+    expect(prePushHook).toContain('workflow-templates/*|\\');
+    expect(prePushHook).toContain('task/*|\\');
     expect(prePushHook).toContain('tests/workflow-templates-e2e.test.mjs|\\');
     expect(prePushHook).toContain('tests/workflow-guaranteed.test.mjs');
     expect(prePushHook).toContain('tests/ui-server.test.mjs');

--- a/tests/workflow-templates.test.mjs
+++ b/tests/workflow-templates.test.mjs
@@ -1877,6 +1877,8 @@ describe("github template CLI compatibility", () => {
     expect(getNodeCommandCode(fetchNode)).toContain("pendingChecks:hasPend");
     expect(getNodeCommandCode(fetchNode)).toContain("sharedFailures=[]");
     expect(getNodeCommandCode(fetchNode)).toContain("collectDefaultBranchFailureNames(repo,baseBranch)");
+    expect(getNodeCommandCode(fetchNode)).toContain("const isSharedFailure=hasFail&&!hasSecurityFail&&!isConflict&&allFailuresOnDefaultBranch;");
+    expect(getNodeCommandCode(fetchNode)).not.toContain("repeatedFailureCount>=2");
     expect(getNodeCommandCode(fetchNode)).toContain("reviewStatus:'shared_ci_failure'");
     expect(getNodeCommandCode(fetchNode)).toContain("failureScope:'shared'");
     expect(getNodeCommandCode(fetchNode)).toContain("taskReviewSignalsUpdated");

--- a/workflow-templates/github.mjs
+++ b/workflow-templates/github.mjs
@@ -1929,7 +1929,7 @@ export const BOSUN_PR_WATCHDOG_TEMPLATE = {
         "  const defaultBranchFailureNames=repo&&base?collectDefaultBranchFailureNames(repo,base):[];",
         "  const defaultBranchFailureSet=new Set((Array.isArray(defaultBranchFailureNames)?defaultBranchFailureNames:[]).map(normalizeCheckKey).filter(Boolean));",
         "  const allFailuresOnDefaultBranch=failedCheckNames.length>0&&failedCheckNames.every((name)=>defaultBranchFailureSet.has(normalizeCheckKey(name)));",
-        "  const isSharedFailure=hasFail&&!hasSecurityFail&&!isConflict&&(allFailuresOnDefaultBranch||repeatedFailureCount>=2);",
+        "  const isSharedFailure=hasFail&&!hasSecurityFail&&!isConflict&&allFailuresOnDefaultBranch;",
         "  const sharedIncidentId=isSharedFailure&&failureFingerprint?[repo,base,failureFingerprint].join(':'):null;",
         "  if(isDraft){drafted.push({n:pr.number,repo});continue;}",
         "  if(!bosunCreated && !attachEligible){skippedUntrusted.push({n:pr.number,repo,reason:'attach_policy_excluded'});continue;}",


### PR DESCRIPTION
## Summary
- route repeated PR branch failures to branch-local repair unless the same checks are proven failing on the default branch
- make pre-push include critical deferred workflow/task/template suites for workflow, task, and template changes
- add regression tests for the watchdog shared-failure predicate and pre-push critical-suite routing

## Validation
- node tools/vitest-runner.mjs run --config vitest.config.mjs --project fast tests/vitest-runner.test.mjs
- node tools/vitest-runner.mjs run --config vitest.config.mjs --project isolated --maxWorkers 1 tests/workflow-templates.test.mjs
- node tools/vitest-runner.mjs run --config vitest.config.mjs --project isolated --maxWorkers 1 tests/workflow-engine.test.mjs -t "action.materialize_planner_tasks"
- npm run build
- git diff --check -- .githooks/pre-push workflow-templates/github.mjs tests/workflow-templates.test.mjs tests/vitest-runner.test.mjs
- git push pre-push hook: passed targeted workflow-engine, workflow-templates, vitest-runner, workflow-new-templates, workflow-engine.tui-status, manual-flows

## Notes
- This fixes why Bosun did not dispatch branch-local fix agents for the current batch of red Bosun-created PRs: repeated branch failures were being classified as shared CI incidents without proving default-branch failure.
- A separate broad local run exposed an unrelated Windows timeout in tests/storage-janitor.test.mjs SQLite VACUUM compaction; that is not part of this fix.