### PR TITLE
fix(workflow): drain template-run dispatch children

### DIFF
--- a/tests/workflow-cli.test.mjs
+++ b/tests/workflow-cli.test.mjs
@@ -8,6 +8,7 @@ import {
   installTemplateRunDependencies,
   listWorkflowSummaries,
   parseWorkflowInput,
+  waitForTemplateRunDispatches,
 } from "../workflow/workflow-cli.mjs";
 
 describe("workflow CLI helpers", () => {
@@ -111,6 +112,19 @@ describe("workflow CLI helpers", () => {
       ]),
     );
     expect(savedIds).toEqual(expect.arrayContaining(installed));
+  });
+
+  it("waits for template-run dispatches added while draining", async () => {
+    const dispatches = [];
+    dispatches.push(Promise.resolve().then(() => {
+      dispatches.push(Promise.resolve({ status: "fulfilled", workflowId: "child-b" }));
+      return { status: "fulfilled", workflowId: "child-a" };
+    }));
+
+    await expect(waitForTemplateRunDispatches(dispatches)).resolves.toEqual([
+      { status: "fulfilled", workflowId: "child-a" },
+      { status: "fulfilled", workflowId: "child-b" },
+    ]);
   });
 
   it("dry-runs workflow-engine templates with traced node output", async () => {

--- a/tests/workflow-cli.test.mjs
+++ b/tests/workflow-cli.test.mjs
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
   executeWorkflowCommand,
+  getTemplateRunDependencyIds,
+  installTemplateRunDependencies,
   listWorkflowSummaries,
   parseWorkflowInput,
 } from "../workflow/workflow-cli.mjs";
@@ -83,6 +85,32 @@ describe("workflow CLI helpers", () => {
     const payload = JSON.parse(stdout[0]);
     expect(payload.some((entry) => entry.id === "template-task-lifecycle")).toBe(true);
     expect(payload.some((entry) => entry.id === "template-backend-agent")).toBe(true);
+  });
+
+  it("resolves required child templates for template-run dispatch targets", () => {
+    expect(getTemplateRunDependencyIds("template-bosun-pr-watchdog")).toEqual(
+      expect.arrayContaining([
+        "template-pr-fix-single",
+        "template-pr-security-fix-single",
+      ]),
+    );
+  });
+
+  it("installs required child templates into template-run engines", () => {
+    const savedIds = [];
+    const installed = installTemplateRunDependencies({
+      save(def) {
+        savedIds.push(def.id);
+      },
+    }, "template-bosun-pr-watchdog");
+
+    expect(installed).toEqual(
+      expect.arrayContaining([
+        "template-pr-fix-single",
+        "template-pr-security-fix-single",
+      ]),
+    );
+    expect(savedIds).toEqual(expect.arrayContaining(installed));
   });
 
   it("dry-runs workflow-engine templates with traced node output", async () => {

--- a/tests/workflow-engine.test.mjs
+++ b/tests/workflow-engine.test.mjs
@@ -893,6 +893,11 @@ describe("WorkflowEngine - loop.for_each", () => {
 
     engine.save(child);
     engine.save(parent);
+    const trackedDispatches = [];
+    engine.trackDispatchedWorkflow = (promise, meta) => {
+      trackedDispatches.push({ promise, meta });
+      return promise;
+    };
     const ctx = await engine.execute(parent.id, {});
     expect(ctx.errors).toEqual([]);
     expect(ctx.getNodeOutput("loop")).toMatchObject({
@@ -903,6 +908,13 @@ describe("WorkflowEngine - loop.for_each", () => {
     expect(ctx.getNodeOutput("loop").results).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ queued: true, mode: "dispatch", workflowId: child.id }),
+      ]),
+    );
+    expect(trackedDispatches).toHaveLength(2);
+    expect(trackedDispatches.map((entry) => entry.meta)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ nodeId: "loop", workflowId: child.id, index: 0 }),
+        expect.objectContaining({ nodeId: "loop", workflowId: child.id, index: 1 }),
       ]),
     );
 

--- a/workflow-templates/github.mjs
+++ b/workflow-templates/github.mjs
@@ -2679,6 +2679,10 @@ export const BOSUN_PR_WATCHDOG_TEMPLATE = {
     createdAt: "2025-07-01T00:00:00Z",
     templateVersion: "3.1.0",
     tags: ["github", "pr", "ci", "merge", "watchdog", "bosun-attached", "safety"],
+    requiredTemplates: [
+      "template-pr-fix-single",
+      "template-pr-security-fix-single",
+    ],
     replaces: {
       module: "agent-hooks.mjs",
       functions: ["registerBuiltinHooks (PostPR block)"],

--- a/workflow/workflow-cli.mjs
+++ b/workflow/workflow-cli.mjs
@@ -8,7 +8,7 @@ import {
   runConfiguredWorkflow,
 } from "./declarative-workflows.mjs";
 import { WorkflowEngine } from "./workflow-engine.mjs";
-import { getTemplate, listTemplates } from "./workflow-templates.mjs";
+import { getTemplate, getTemplateGroup, listTemplates } from "./workflow-templates.mjs";
 import { inspectCustomWorkflowNodePlugins } from "./workflow-nodes.mjs";
 
 function hasFlag(args, ...flags) {
@@ -101,6 +101,25 @@ export function listWorkflowSummaries(config = loadConfig(process.argv)) {
 
 function cloneJson(value) {
   return value == null ? value ?? null : JSON.parse(JSON.stringify(value));
+}
+
+export function getTemplateRunDependencyIds(templateId) {
+  const group = getTemplateGroup(templateId);
+  if (!group || !Array.isArray(group.members)) return [];
+  return group.members.filter((memberId) => memberId && memberId !== templateId);
+}
+
+export function installTemplateRunDependencies(engine, templateId) {
+  if (!engine || typeof engine.save !== "function") return [];
+  const dependencyIds = getTemplateRunDependencyIds(templateId);
+  const installed = [];
+  for (const dependencyId of dependencyIds) {
+    const dependency = getTemplate(dependencyId);
+    if (!dependency) continue;
+    engine.save(cloneJson(dependency));
+    installed.push(dependencyId);
+  }
+  return installed;
 }
 
 function formatConsoleCaptureArg(value) {
@@ -284,6 +303,7 @@ export async function executeWorkflowCommand(args, options = {}) {
         services: options.services || {},
         detectInterruptedRuns: false,
       });
+      installTemplateRunDependencies(engine, templateId);
       engine.on("workflow:status", (event) => {
         statusEvents.push(cloneJson(event));
       });

--- a/workflow/workflow-cli.mjs
+++ b/workflow/workflow-cli.mjs
@@ -122,6 +122,17 @@ export function installTemplateRunDependencies(engine, templateId) {
   return installed;
 }
 
+export async function waitForTemplateRunDispatches(dispatches = []) {
+  const results = [];
+  let index = 0;
+  while (index < dispatches.length) {
+    const batch = dispatches.slice(index);
+    index = dispatches.length;
+    results.push(...await Promise.all(batch));
+  }
+  return results;
+}
+
 function formatConsoleCaptureArg(value) {
   if (typeof value === "string") return value;
   try {
@@ -175,6 +186,7 @@ function buildTemplateRunReport(template, ctx, statusEvents = [], options = {}) 
     logs: Array.isArray(ctx?.logs) ? [...ctx.logs] : [],
     statusEvents: Array.isArray(statusEvents) ? statusEvents.map((entry) => ({ ...entry })) : [],
     engineConsole: Array.isArray(options.engineConsole) ? options.engineConsole.map((entry) => ({ ...entry })) : [],
+    dispatches: Array.isArray(options.dispatches) ? options.dispatches.map((entry) => cloneJson(entry)) : [],
     data: cloneJson(ctx?.data || {}),
     nodes: nodes.map((node) => ({
       id: node?.id || null,
@@ -194,6 +206,11 @@ function formatTemplateRunReport(report = {}) {
   ];
   for (const node of report?.nodes || []) {
     lines.push(`- ${node.id}\t${node.status}\t${node.type}`);
+  }
+  const dispatches = Array.isArray(report?.dispatches) ? report.dispatches : [];
+  if (dispatches.length > 0) {
+    const failed = dispatches.filter((entry) => entry?.status !== "fulfilled" || entry?.success === false).length;
+    lines.push(`dispatches=${dispatches.length} failed=${failed}`);
   }
   const logTail = Array.isArray(report?.logs) ? report.logs.slice(-12) : [];
   for (const entry of logTail) {
@@ -304,6 +321,30 @@ export async function executeWorkflowCommand(args, options = {}) {
         detectInterruptedRuns: false,
       });
       installTemplateRunDependencies(engine, templateId);
+      const dispatchedWorkflows = [];
+      engine.trackDispatchedWorkflow = (promise, meta = {}) => {
+        const tracked = Promise.resolve(promise)
+          .then((runCtx) => ({
+            status: "fulfilled",
+            success: !(Array.isArray(runCtx?.errors) && runCtx.errors.length > 0),
+            workflowId: meta?.workflowId || null,
+            nodeId: meta?.nodeId || null,
+            index: Number.isFinite(Number(meta?.index)) ? Number(meta.index) : null,
+            runId: runCtx?.id || null,
+            errors: Array.isArray(runCtx?.errors) ? [...runCtx.errors] : [],
+          }))
+          .catch((error) => ({
+            status: "rejected",
+            success: false,
+            workflowId: meta?.workflowId || null,
+            nodeId: meta?.nodeId || null,
+            index: Number.isFinite(Number(meta?.index)) ? Number(meta.index) : null,
+            runId: null,
+            errors: [error?.message || String(error)],
+          }));
+        dispatchedWorkflows.push(tracked);
+        return tracked;
+      };
       engine.on("workflow:status", (event) => {
         statusEvents.push(cloneJson(event));
       });
@@ -314,9 +355,24 @@ export async function executeWorkflowCommand(args, options = {}) {
           force: true,
         })
       ));
+      const dispatchResults = dryRun ? [] : await waitForTemplateRunDispatches(dispatchedWorkflows);
+      const dispatchFailures = dispatchResults.filter((entry) => entry?.success === false);
+      if (dispatchFailures.length > 0) {
+        if (!Array.isArray(ctx.errors)) ctx.errors = [];
+        for (const failure of dispatchFailures) {
+          const label = failure?.workflowId || "unknown";
+          const index = failure?.index === null || failure?.index === undefined ? "unknown" : failure.index;
+          const detail = Array.isArray(failure?.errors) && failure.errors.length > 0
+            ? failure.errors.join("; ")
+            : "child workflow failed";
+          ctx.errors.push(`Dispatched workflow ${label}[${index}] failed: ${detail}`);
+        }
+        ctx.data._workflowTerminalStatus = "failed";
+      }
       const report = buildTemplateRunReport(template, ctx, statusEvents, {
         dryRun,
         engineConsole: consoleLines,
+        dispatches: dispatchResults,
       });
       if (asJson || options.forceJsonOutput === true) {
         stdout(JSON.stringify(report, null, 2));

--- a/workflow/workflow-nodes/loop.mjs
+++ b/workflow/workflow-nodes/loop.mjs
@@ -244,7 +244,19 @@ registerNodeType("loop.for_each", {
           }
           try {
             if (subWorkflowMode === "dispatch") {
-              Promise.resolve(engine.execute(subWorkflowId, itemData))
+              const dispatchedWorkflow = Promise.resolve(engine.execute(subWorkflowId, itemData));
+              if (typeof engine.trackDispatchedWorkflow === "function") {
+                try {
+                  engine.trackDispatchedWorkflow(dispatchedWorkflow, {
+                    nodeId: node.id,
+                    workflowId: subWorkflowId,
+                    index: itemIndex,
+                  });
+                } catch (trackErr) {
+                  ctx.log(node.id, `Loop dispatch item ${itemIndex} tracking failed: ${trackErr?.message || trackErr}`, "warn");
+                }
+              }
+              dispatchedWorkflow
                 .then((runCtx) => {
                   const status = Array.isArray(runCtx?.errors) && runCtx.errors.length > 0 ? "failed" : "completed";
                   ctx.log(node.id, `Loop dispatch item ${itemIndex} finished with status=${status}`);


### PR DESCRIPTION
## Summary
- installs required child templates before `workflow template-run` executes template roots
- tracks dispatch-mode child workflows launched by `loop.for_each`
- drains template-run child dispatches before reporting success so simulator/watchdog runs cannot exit before fix-agent workflows finish

## Validation
- `node tools\vitest-runner.mjs run --config vitest.config.mjs --project fast tests\workflow-cli.test.mjs`
- `node tools\vitest-runner.mjs run --config vitest.config.mjs --project isolated tests\workflow-engine.test.mjs -t "dispatches child workflows without waiting"`
- `npm run syntax:check`
- `npm run build`
- `git push -u origin codex/pr-watchdog-template-dispatch` pre-push hook: 759 isolated workflow tests, 922 fast tests, 13 node tests

## Simulator Evidence
- Reran `template-bosun-pr-watchdog` with `allowPush:true` after clearing stale local claims.
- The watchdog dispatched branch-local fix workflows for PRs #502/#503/#504/#506/#507/#508/#510/#511/#512 and pushed new head SHAs to all nine PR branches.