### PR TITLE
fix(workflow): release PR fix claims from Bosun home

### DIFF
--- a/tests/continue-detection.test.mjs
+++ b/tests/continue-detection.test.mjs
@@ -15,9 +15,10 @@ import { createSessionTracker } from "../infra/session-tracker.mjs";
 
 describe("SessionTracker.getProgressStatus", () => {
   let tracker;
+  const idleThresholdMs = 10_000;
 
   beforeEach(() => {
-    tracker = createSessionTracker({ maxMessages: 20, idleThresholdMs: 100 });
+    tracker = createSessionTracker({ maxMessages: 20, idleThresholdMs });
   });
 
   it("returns not_found for unknown taskId", () => {
@@ -55,22 +56,22 @@ describe("SessionTracker.getProgressStatus", () => {
       item: { type: "agent_message", text: "did something" },
     });
 
-    // Hack lastActivityAt to simulate idle (150ms is between idle=100ms and stalled=200ms thresholds)
+    // Hack lastActivityAt to simulate idle (between idle and stalled thresholds)
     const session = tracker.getSession("task-1");
-    session.lastActivityAt = Date.now() - 150;
+    session.lastActivityAt = Date.now() - idleThresholdMs * 1.5;
 
     const status = tracker.getProgressStatus("task-1");
     expect(status.status).toBe("idle");
-    expect(status.idleMs).toBeGreaterThan(100);
+    expect(status.idleMs).toBeGreaterThan(idleThresholdMs);
     expect(status.recommendation).toBe("continue"); // has events, so continue
   });
 
   it("returns nudge recommendation when idle with 0 events", () => {
     tracker.startSession("task-1", "Test");
 
-    // Make idle without any events (150ms is between idle=100ms and stalled=200ms thresholds)
+    // Make idle without any events (between idle and stalled thresholds)
     const session = tracker.getSession("task-1");
-    session.lastActivityAt = Date.now() - 150;
+    session.lastActivityAt = Date.now() - idleThresholdMs * 1.5;
 
     const status = tracker.getProgressStatus("task-1");
     expect(status.status).toBe("idle");
@@ -80,7 +81,7 @@ describe("SessionTracker.getProgressStatus", () => {
   it("does not treat turn_context noise as real activity", () => {
     tracker.startSession("task-1", "Test");
     const session = tracker.getSession("task-1");
-    session.lastActivityAt = Date.now() - 150;
+    session.lastActivityAt = Date.now() - idleThresholdMs * 1.5;
 
     tracker.recordEvent("task-1", { type: "turn_context" });
     tracker.recordEvent("task-1", {
@@ -251,9 +252,10 @@ describe("shouldAutoResume patterns", () => {
 
 describe("idle detection integration", () => {
   let tracker;
+  const idleThresholdMs = 5_000;
 
   beforeEach(() => {
-    tracker = createSessionTracker({ maxMessages: 20, idleThresholdMs: 50 });
+    tracker = createSessionTracker({ maxMessages: 20, idleThresholdMs });
   });
 
   it("full lifecycle: active → idle → continue recommendation", () => {
@@ -276,7 +278,7 @@ describe("idle detection integration", () => {
 
     // Simulate agent going idle
     const session = tracker.getSession("task-1");
-    session.lastActivityAt = Date.now() - 80; // between idle=50ms and stalled=100ms thresholds
+    session.lastActivityAt = Date.now() - idleThresholdMs * 1.5; // between idle and stalled thresholds
 
     // Should now be idle with continue recommendation
     progress = tracker.getProgressStatus("task-1");
@@ -321,9 +323,9 @@ describe("idle detection integration", () => {
     tracker.startSession("task-3", "Done");
     tracker.endSession("task-3", "completed");
 
-    // Make task-2 idle (between idleThreshold=50 and stalledThreshold=100)
+    // Make task-2 idle (between idle and stalled thresholds)
     const session2 = tracker.getSession("task-2");
-    session2.lastActivityAt = Date.now() - 80;
+    session2.lastActivityAt = Date.now() - idleThresholdMs * 1.5;
 
     const active = tracker.getActiveSessions();
     expect(active).toHaveLength(2);
@@ -331,7 +333,7 @@ describe("idle detection integration", () => {
     // Find idle session
     const idleSession = active.find((s) => s.taskId === "task-2");
     expect(idleSession).toBeTruthy();
-    expect(idleSession.idleMs).toBeGreaterThan(50);
+    expect(idleSession.idleMs).toBeGreaterThan(idleThresholdMs);
 
     // Check if it should get a CONTINUE
     const progress = tracker.getProgressStatus("task-2");
@@ -345,7 +347,7 @@ describe("continue prompt building", () => {
   let tracker;
 
   beforeEach(() => {
-    tracker = createSessionTracker({ maxMessages: 20, idleThresholdMs: 50 });
+    tracker = createSessionTracker({ maxMessages: 20, idleThresholdMs: 5_000 });
   });
 
   it("progress status reflects edits for commit nudge", () => {
@@ -396,9 +398,10 @@ describe("continue prompt building", () => {
 
 describe("edge cases", () => {
   let tracker;
+  const idleThresholdMs = 10_000;
 
   beforeEach(() => {
-    tracker = createSessionTracker({ maxMessages: 10, idleThresholdMs: 100 });
+    tracker = createSessionTracker({ maxMessages: 10, idleThresholdMs });
   });
 
   it("handles rapid session restart gracefully", () => {
@@ -417,7 +420,7 @@ describe("edge cases", () => {
   });
 
   it("stalled status threshold is 2x idle threshold", () => {
-    tracker = createSessionTracker({ maxMessages: 10, idleThresholdMs: 50 });
+    tracker = createSessionTracker({ maxMessages: 10, idleThresholdMs });
     tracker.startSession("task-1", "Test");
     tracker.recordEvent("task-1", {
       type: "item.completed",
@@ -426,13 +429,13 @@ describe("edge cases", () => {
 
     // Set to 1.5x threshold — should be idle, not stalled
     const session = tracker.getSession("task-1");
-    session.lastActivityAt = Date.now() - 75; // 1.5x of 50ms
+    session.lastActivityAt = Date.now() - idleThresholdMs * 1.5;
 
     let progress = tracker.getProgressStatus("task-1");
     expect(progress.status).toBe("idle");
 
     // Set to 2.5x threshold — should be stalled
-    session.lastActivityAt = Date.now() - 125; // 2.5x of 50ms
+    session.lastActivityAt = Date.now() - idleThresholdMs * 2.5;
     progress = tracker.getProgressStatus("task-1");
     // Due to order: stalled check (>2x) comes after idle check (>1x)
     // The code checks idle first, so at 2.5x, idle fires

--- a/tests/workflow-templates.test.mjs
+++ b/tests/workflow-templates.test.mjs
@@ -1971,6 +1971,8 @@ describe("github template CLI compatibility", () => {
     const claimNode = watchdogTemplate.nodes.find((n) => n.id === "claim-unclaimed-prs");
     const dispatchNode = watchdogTemplate.nodes.find((n) => n.id === "dispatch-fix-agents");
     const singleFixTemplate = getTemplate("template-pr-fix-single");
+    const singleFixAgentNode = singleFixTemplate.nodes.find((n) => n.id === "fix-agent");
+    const singleFixReleaseNode = singleFixTemplate.nodes.find((n) => n.id === "release-claim");
     const singleFixPushNode = singleFixTemplate.nodes.find((n) => n.id === "push-fixes");
     const singleFixSiblingNode = singleFixTemplate.nodes.find((n) => n.id === "update-sibling-branches");
     const command = getNodeCommandCode(fixNode);
@@ -2000,6 +2002,10 @@ describe("github template CLI compatibility", () => {
     expect(dispatchNode?.config?.mode).toBe("dispatch");
     expect(dispatchNode?.config?.workflowId).toBe("template-pr-fix-single");
     expect(singleFixTemplate?.trigger).toBe("trigger.manual");
+    expect(singleFixAgentNode?.config?.prompt).toContain("Do NOT run raw `npm test`");
+    expect(singleFixAgentNode?.config?.prompt).toContain("tools/vitest-runner.mjs");
+    expect(getNodeCommandCode(singleFixReleaseNode)).toContain("process.env.BOSUN_HOME");
+    expect(getNodeCommandCode(singleFixReleaseNode)).toContain("path.join(bosunHome,'tmp')");
     expect(getNodeCommandCode(singleFixPushNode)).toContain("push_disabled");
     expect(singleFixPushNode?.config?.env?.ALLOW_PUSH).toBe("{{allowPush}}");
     expect(getNodeCommandCode(singleFixSiblingNode)).toContain("push_disabled");

--- a/workflow-templates/github.mjs
+++ b/workflow-templates/github.mjs
@@ -1474,6 +1474,9 @@ export const BOSUN_PR_PROGRESSOR_TEMPLATE = {
         "- For merge conflicts: `git merge origin/{{setup-pr-worktree.output.base}}` and resolve.\n" +
         "- For CI failures: study the error output and apply the MINIMAL code fix.\n" +
         "- For review feedback: address each comment precisely.\n" +
+        "- Validation rule: do NOT run raw `npm test` from this ephemeral PR-fix agent. In this repo, raw `npm test` exceeds the agent command budget and stalls repair.\n" +
+        "- For Node/Vitest worktrees with `tools/vitest-runner.mjs`, run the narrowest relevant command first, for example `node tools/vitest-runner.mjs run --config vitest.config.mjs --project isolated tests/<target>.test.mjs --reporter dot`.\n" +
+        "- If a full-suite signal is still needed, leave a note in your final response; the workflow/operator will run the broad suite after the focused branch fix is committed.\n" +
         "- After fixing, remove the label:\n" +
         "  `gh pr edit {{setup-pr-worktree.output.number}} --repo {{setup-pr-worktree.output.repo}} --remove-label bosun-needs-fix`\n",
       sdk: "auto",
@@ -3227,10 +3230,15 @@ export const PR_FIX_SINGLE_TEMPLATE = {
         "- `merge_conflict_requires_code_resolution`: Run `git merge origin/{{setup-worktree.output.base}}`, " +
         "  resolve *all* conflicts in code, run available tests, then `git commit`.\n" +
         "- `auto_rerun_limit_reached` / `ci_rerun_failed`: Study the failed log excerpt and " +
-        "  job details to find the root cause. Fix the code, run tests, `git add` and `git commit`.\n" +
+        "  job details to find the root cause. Fix the code, run focused tests, `git add` and `git commit`.\n" +
         "- `no_rerunnable_failed_run_found`: Look at `gh pr checks` for this PR, inspect the failure, " +
         "  fix the issue, and commit.\n" +
         "- `branch_update_failed` / `missing_repo_or_branch`: Inspect with `gh pr view`, diagnose, fix.\n\n" +
+        "**Validation rule:** Do NOT run raw `npm test` from this ephemeral PR-fix agent. In this repo, raw `npm test` exceeds the agent command budget and stalls repair. If `tools/vitest-runner.mjs` exists, run the narrowest relevant focused command first, for example:\n" +
+        "```\n" +
+        "node tools/vitest-runner.mjs run --config vitest.config.mjs --project isolated tests/<target>.test.mjs --reporter dot\n" +
+        "```\n" +
+        "If the fix genuinely needs full-suite validation, say so in your final response; the workflow/operator will run the broad suite after the branch-local fix is committed.\n\n" +
         "**After fixing:** Commit with a clear message like `fix: resolve CI failure in <check_name>`.\n" +
         "Then remove the fix label:\n" +
         "```\n" +
@@ -3365,7 +3373,9 @@ export const PR_FIX_SINGLE_TEMPLATE = {
         "const path=require('path');",
         "const claimKey=String(process.env.PR_CLAIM_KEY||'').trim();",
         "if(!claimKey){console.log(JSON.stringify({released:false,reason:'no_claim_key'}));process.exit(0);}",
-        "const CLAIM_FILE=path.join(process.cwd(),'.cache','bosun','pr-fix-claims.json');",
+        "const bosunHome=String(process.env.BOSUN_HOME||'').trim();",
+        "const claimDir=bosunHome?path.join(bosunHome,'tmp'):path.join(process.cwd(),'.cache','bosun');",
+        "const CLAIM_FILE=path.join(claimDir,'pr-fix-claims.json');",
         "try{",
         "  if(!fs.existsSync(CLAIM_FILE)){console.log(JSON.stringify({released:false,reason:'no_claim_file'}));process.exit(0);}",
         "  const data=JSON.parse(fs.readFileSync(CLAIM_FILE,'utf8'));",


### PR DESCRIPTION
## Summary
- release generic PR-fix claims from BOSUN_HOME/tmp so dispatched single-PR agents do not leave stale claims when the watchdog runs with --config-dir
- instruct PR-fix agents to run focused vitest-runner commands instead of raw npm test, which exceeds the ephemeral agent command budget
- pin the watchdog template contract with regression assertions

## Validation
- node tools/vitest-runner.mjs run --config vitest.config.mjs --project isolated tests/workflow-templates.test.mjs -t "PR watchdog" --reporter dot
- npm run syntax:check
- git diff --check
- pre-push checks passed on push