### PR TITLE
ci: bound CodeQL analysis scope

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,14 @@
+name: bosun-codeql
+
+paths-ignore:
+  - ".bosun/**"
+  - ".cache/**"
+  - "coverage/**"
+  - "dist/**"
+  - "node_modules/**"
+  - "site/ui/demo.html"
+  - "site/ui/vendor/**"
+  - "tmp/**"
+  - "ui/demo.html"
+  - "ui/vendor/**"
+  - "workspace/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "27 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
+          - rust
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- replace dynamic default CodeQL with an explicit repo-owned workflow
- add a 30 minute CodeQL timeout so JS/TS analysis cannot leave main indefinitely pending
- ignore generated, workspace, cache, and vendored UI artifacts during CodeQL analysis

## Validation
- npm run syntax:check
- npm run build
- git push pre-push hook