### PR TITLE
ci: give CodeQL JavaScript analysis more time

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,14 +18,17 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: ${{ matrix.timeout-minutes }}
     strategy:
       fail-fast: false
       matrix:
-        language:
-          - actions
-          - javascript-typescript
-          - rust
+        include:
+          - language: actions
+            timeout-minutes: 30
+          - language: javascript-typescript
+            timeout-minutes: 60
+          - language: rust
+            timeout-minutes: 30
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Give the CodeQL JavaScript/TypeScript matrix job a 60 minute timeout while keeping Actions and Rust at 30 minutes.
- Preserve the existing CodeQL languages and config file.

## Validation
- npm run syntax:check
- npm test
- npm run build
- pre-push hook passed during git push

## Context
Main commit 0596331b has CodeQL stuck in Perform CodeQL Analysis for Analyze (javascript-typescript), while the Actions and Rust CodeQL jobs completed successfully.