### PR TITLE
fix: stabilize monitor reload and PR handoff conditions

### DIFF
--- a/infra/monitor.mjs
+++ b/infra/monitor.mjs
@@ -3188,6 +3188,18 @@ function isFlowReviewGateEnabled() {
   return !isFalsyFlag(flowRequireReviewDefault);
 }
 
+function isMonitorMonitorEnabled() {
+  if (isMonitorTestRuntime) return false;
+
+  const explicit =
+    process.env.DEVMODE_MONITOR_MONITOR_ENABLED ??
+    process.env.DEVMODE_AUTO_CODE_FIX_ENABLED;
+  if (explicit !== undefined && String(explicit).trim() !== "") {
+    return !isFalsyFlag(explicit);
+  }
+
+  return false;
+}
 
 function isSelfRestartWatcherEnabled() {
   const devMode = isDevMode();

--- a/site/ui/demo-defaults.js
+++ b/site/ui/demo-defaults.js
@@ -7288,7 +7288,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr')?.prNumber || $ctx.getNodeOutput('create-pr')?.prUrl)"
           },
           "position": {
             "x": 400,
@@ -7531,7 +7531,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr-retry')?.prNumber || $ctx.getNodeOutput('create-pr-retry')?.prUrl)"
           },
           "position": {
             "x": 400,
@@ -7759,7 +7759,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr-retry2')?.prNumber || $ctx.getNodeOutput('create-pr-retry2')?.prUrl)"
           },
           "position": {
             "x": 400,
@@ -32953,7 +32953,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr')?.prNumber || $ctx.getNodeOutput('create-pr')?.prUrl)"
           },
           "position": {
             "x": 400,
@@ -33196,7 +33196,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr-retry')?.prNumber || $ctx.getNodeOutput('create-pr-retry')?.prUrl)"
           },
           "position": {
             "x": 400,
@@ -33424,7 +33424,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr-retry2')?.prNumber || $ctx.getNodeOutput('create-pr-retry2')?.prUrl)"
           },
           "position": {
             "x": 400,

--- a/tests/monitor-workflow-startup-guards.test.mjs
+++ b/tests/monitor-workflow-startup-guards.test.mjs
@@ -66,10 +66,13 @@ describe("monitor workflow startup guards", () => {
   it("declares monitor-monitor runtime state before reload-time helpers use it", () => {
     expect(monitorSource).toContain("const monitorMonitor = {");
     expect(monitorSource).toContain("sdkFailures: new Map()");
+    expect(monitorSource).toContain("function isMonitorMonitorEnabled()");
+    expect(monitorSource).toContain("DEVMODE_MONITOR_MONITOR_ENABLED");
+    expect(monitorSource).toContain("DEVMODE_AUTO_CODE_FIX_ENABLED");
     expect(monitorSource).toContain("function refreshMonitorMonitorRuntime()");
     expect(monitorSource).toContain("const previousMonitorRuntime = snapshotMonitorMonitorRuntime();");
     expect(
-      monitorSource.indexOf("const monitorMonitor = {"),
+      monitorSource.indexOf("function isMonitorMonitorEnabled()"),
     ).toBeLessThan(
       monitorSource.indexOf("function refreshMonitorMonitorRuntime()"),
     );

--- a/tests/workflow-templates.test.mjs
+++ b/tests/workflow-templates.test.mjs
@@ -701,9 +701,13 @@ describe("workflow-templates", () => {
     const backendRetryGate = backendTemplate.nodes.find((n) => n.id === "retry-pr-ok");
     expect(backendGate?.config?.expression).toContain("prNumber");
     expect(backendGate?.config?.expression).toContain("prUrl");
+    expect(backendGate?.config?.expression).toContain("create-pr");
+    expect(backendGate?.config?.expression).not.toContain("$edge");
     expect(backendGate?.config?.expression).not.toContain("success === true");
     expect(backendRetryGate?.config?.expression).toContain("prNumber");
     expect(backendRetryGate?.config?.expression).toContain("prUrl");
+    expect(backendRetryGate?.config?.expression).toContain("create-pr-retry");
+    expect(backendRetryGate?.config?.expression).not.toContain("$edge");
     expect(backendRetryGate?.config?.expression).not.toContain("success === true");
   });
 

--- a/ui/demo-defaults.js
+++ b/ui/demo-defaults.js
@@ -7288,7 +7288,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr')?.prNumber || $ctx.getNodeOutput('create-pr')?.prUrl)"
           },
           "position": {
             "x": 400,
@@ -7531,7 +7531,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr-retry')?.prNumber || $ctx.getNodeOutput('create-pr-retry')?.prUrl)"
           },
           "position": {
             "x": 400,
@@ -7759,7 +7759,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr-retry2')?.prNumber || $ctx.getNodeOutput('create-pr-retry2')?.prUrl)"
           },
           "position": {
             "x": 400,
@@ -32953,7 +32953,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr')?.prNumber || $ctx.getNodeOutput('create-pr')?.prUrl)"
           },
           "position": {
             "x": 400,
@@ -33196,7 +33196,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr-retry')?.prNumber || $ctx.getNodeOutput('create-pr-retry')?.prUrl)"
           },
           "position": {
             "x": 400,
@@ -33424,7 +33424,7 @@
           "type": "condition.expression",
           "label": "PR Created?",
           "config": {
-            "expression": "Boolean($ctx.getNodeOutput($edge.source)?.prNumber || $ctx.getNodeOutput($edge.source)?.prUrl)"
+            "expression": "Boolean($ctx.getNodeOutput('create-pr-retry2')?.prNumber || $ctx.getNodeOutput('create-pr-retry2')?.prUrl)"
           },
           "position": {
             "x": 400,

--- a/workflow-templates/agents.mjs
+++ b/workflow-templates/agents.mjs
@@ -503,9 +503,27 @@ export const BACKEND_AGENT_TEMPLATE = (() => {
   const mainValidation = embedSubWorkflow(VALIDATION_GATE_SUB, "main-");
   const retryValidation = embedSubWorkflow(VALIDATION_GATE_SUB, "retry-");
   const retry2Validation = embedSubWorkflow(VALIDATION_GATE_SUB, "retry2-");
-  const mainPrHandoff = embedSubWorkflow(PR_CHECK_HANDOFF_SUB, "main-");
-  const retryPrHandoff = embedSubWorkflow(PR_CHECK_HANDOFF_SUB, "retry-");
-  const retry2PrHandoff = embedSubWorkflow(PR_CHECK_HANDOFF_SUB, "retry2-");
+  const mainPrHandoff = embedSubWorkflow(PR_CHECK_HANDOFF_SUB, "main-", {
+    nodeOverrides: {
+      "pr-ok": {
+        expression: "Boolean($ctx.getNodeOutput('create-pr')?.prNumber || $ctx.getNodeOutput('create-pr')?.prUrl)",
+      },
+    },
+  });
+  const retryPrHandoff = embedSubWorkflow(PR_CHECK_HANDOFF_SUB, "retry-", {
+    nodeOverrides: {
+      "pr-ok": {
+        expression: "Boolean($ctx.getNodeOutput('create-pr-retry')?.prNumber || $ctx.getNodeOutput('create-pr-retry')?.prUrl)",
+      },
+    },
+  });
+  const retry2PrHandoff = embedSubWorkflow(PR_CHECK_HANDOFF_SUB, "retry2-", {
+    nodeOverrides: {
+      "pr-ok": {
+        expression: "Boolean($ctx.getNodeOutput('create-pr-retry2')?.prNumber || $ctx.getNodeOutput('create-pr-retry2')?.prUrl)",
+      },
+    },
+  });
 
   return {
     id: "template-backend-agent",


### PR DESCRIPTION
## Summary
- restore the monitor-monitor enablement helper so config reloads do not throw at runtime
- replace PR handoff condition expressions that depended on unavailable \$edge\ context with explicit create-pr node lookups
- regenerate demo defaults so installed templates match the source template

## Validation
- npm exec vitest -- run tests/workflow-templates.test.mjs tests/monitor-workflow-startup-guards.test.mjs
- npm run syntax:check
- npm test
- npm run build
- git diff --check
- pre-push hook during git push